### PR TITLE
Toggle generation of mp4 recordings

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Ansible role for a bigbluebutton installation (following the documentation on ht
 | `bbb_ntp_cron_hour` | Hour when the time-sync job should run | `5`
 | `bbb_ntp_cron_minute` | Minute when the time-sync job should run | `0`
 | `bbb_html5_node_options` | Allow to set extra options for node for the html5-webclient | unset | Could be used for example with https://github.com/bigbluebutton/bigbluebutton/issues/11183 ; `--max-old-space-size=4096 --max_semi_space_size=128`
+| `bbb_recordings_mp4` | Generate mp4 files of recordings for compatibility with IOS devices. See [this]<https://docs.bigbluebutton.org/2.2/customize.html#enable-playback-of-recordings-on-ios> for documentation. | `false` | To apply this to existing recordings, you will need to rebuild them using `sudo bbb-record --rebuildall`. |
 
 ### Extra options for Greenlight
 The Web-Frontend has some extra configuration options, listed below:

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Ansible role for a bigbluebutton installation (following the documentation on ht
 | `bbb_ntp_cron_hour` | Hour when the time-sync job should run | `5`
 | `bbb_ntp_cron_minute` | Minute when the time-sync job should run | `0`
 | `bbb_html5_node_options` | Allow to set extra options for node for the html5-webclient | unset | Could be used for example with https://github.com/bigbluebutton/bigbluebutton/issues/11183 ; `--max-old-space-size=4096 --max_semi_space_size=128`
+| `bbb_recordings_webm` | Generate webm files of recordings. See [this]<https://docs.bigbluebutton.org/2.2/customize.html#enable-playback-of-recordings-on-ios> for documentation. | `true` | To apply this to existing recordings, you will need to rebuild them using `sudo bbb-record --rebuildall`. You must either have this set and or `bbb_recordings_mp4` to `true` or stuff will break. |
 | `bbb_recordings_mp4` | Generate mp4 files of recordings for compatibility with IOS devices. See [this]<https://docs.bigbluebutton.org/2.2/customize.html#enable-playback-of-recordings-on-ios> for documentation. | `false` | To apply this to existing recordings, you will need to rebuild them using `sudo bbb-record --rebuildall`. |
 
 ### Extra options for Greenlight

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -86,3 +86,5 @@ bbb_ntp_cron: false
 bbb_ntp_cron_day: "*"
 bbb_ntp_cron_hour: "5"
 bbb_ntp_cron_minute: "0"
+
+bbb_recordings_mp4: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -87,4 +87,5 @@ bbb_ntp_cron_day: "*"
 bbb_ntp_cron_hour: "5"
 bbb_ntp_cron_minute: "0"
 
+bbb_recordings_webm: true
 bbb_recordings_mp4: false

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -72,6 +72,7 @@
   command: bbb-conf --secret
   changed_when: false
   register: result
+  check_mode: no
 
 - name: parse bbb secret
   set_fact:
@@ -357,3 +358,23 @@
     replace: 'PORT=3000 /usr/share/$NODE_VERSION/bin/node main.js'
   when: not bbb_html5_node_options is defined
   notify: restart bigbluebutton
+
+- name: Enable mp4 for recordings
+  replace:
+    path: /usr/local/bigbluebutton/core/scripts/presentation.yml
+    regexp: '^video_formats:\s*\n\s*-\s*webm\n#*\s*-\s*mp4$'
+    replace: |-
+      video_formats:
+        - webm
+        - mp4
+  when: bbb_recordings_mp4
+
+- name: Disable mp4 for recordings
+  replace:
+    path: /usr/local/bigbluebutton/core/scripts/presentation.yml
+    regexp: '^video_formats:\s*\n\s*-\s*webm\n#*\s*-\s*mp4$'
+    replace: |-
+      video_formats:
+        - webm
+        # - mp4
+  when: not bbb_recordings_mp4

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -72,7 +72,6 @@
   command: bbb-conf --secret
   changed_when: false
   register: result
-  check_mode: no
 
 - name: parse bbb secret
   set_fact:
@@ -359,22 +358,11 @@
   when: not bbb_html5_node_options is defined
   notify: restart bigbluebutton
 
-- name: Enable mp4 for recordings
+- name: Set recording formats
   replace:
     path: /usr/local/bigbluebutton/core/scripts/presentation.yml
-    regexp: '^video_formats:\s*\n\s*-\s*webm\n#*\s*-\s*mp4$'
+    regexp: '^video_formats:\s*\n\s*#?\s*-\s*webm\n\s*#*\s*-\s*mp4$'
     replace: |-
       video_formats:
-        - webm
-        - mp4
-  when: bbb_recordings_mp4
-
-- name: Disable mp4 for recordings
-  replace:
-    path: /usr/local/bigbluebutton/core/scripts/presentation.yml
-    regexp: '^video_formats:\s*\n\s*-\s*webm\n#*\s*-\s*mp4$'
-    replace: |-
-      video_formats:
-        - webm
-        # - mp4
-  when: not bbb_recordings_mp4
+        {{ bbb_recordings_webm | ternary('', '#') }}- webm
+        {{ bbb_recordings_mp4 | ternary('', '#') }}- mp4


### PR DESCRIPTION
According to the BBB Docs[^0], IOS only supports mp4 files. There is the
possibility to render recordings also to mp4, but it's disabled by
default. Using `bbb_recordings_mp4` (defaults to `false` => nothing
changed) the generation of mp4 recordings can be enabled.

[^0]: https://docs.bigbluebutton.org/2.2/customize.html#enable-playback-of-recordings-on-ios