### PR TITLE
Allow modification of RTP ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Ansible role for a bigbluebutton installation (following the documentation on ht
 | `bbb_freeswitch_ioschedule_realtime` | [IOSchedulingClass](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#IOSchedulingClass=) | `true` | Set this to `false` for LXD/LXC Compatibility |
 | `bbb_freeswitch_ipv6` | Enable IPv6 support in FreeSWITCH | `true` | Disable to fix [FreeSWITCH IPv6 error][bbb_freeswitch_ipv6] |
 | `bbb_freeswitch_external_ip` | Set stun server for sip and rtp on FreeSWITCH | `stun:{{ (bbb_stun_servers \| first).server }}` | WARNING: the value of the default freeswitch installation is `stun:stun.freeswitch.org` |
+| `bbb_freeswitch_rtp_start_port` | RTP start port of FreeSWITCH | 16384 |
+| `bbb_freeswitch_rtp_end_port` | RTP end port of FreeSWITCH | 24576 |
+| `bbb_kurento_rtp_start_port` | RTP start port of Kurento | 24577 |
+| `bbb_kurento_rtp_end_port` | RTP end port of Kurento | 32768 |
 | `bbb_dialplan_quality` | Set quality of dailplan for FreeSWITCH | `cdquality` |
 | `bbb_dialplan_energy_level` | Set energy level of dailplan for FreeSWITCH | `100` | only for selected profile `bbb_dialplan_quality`
 | `bbb_dialplan_comfort_noise` | Set comfort noise of dailplan for FreeSWITCH | `1400` | only for selected profile `bbb_dialplan_quality`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,6 +44,11 @@ bbb_cpuschedule: true
 bbb_freeswitch_ioschedule_realtime: true
 bbb_freeswitch_ipv6: true
 bbb_freeswitch_external_ip: "stun:{{ (bbb_stun_servers | first).server }}"
+bbb_freeswitch_rtp_start_port: 16384
+bbb_freeswitch_rtp_end_port: 24576
+
+bbb_kurento_rtp_start_port: 24577
+bbb_kurento_rtp_end_port: 32768
 
 # ALWAYS_ACCEPT, ALWAYS_DENY, ASK_MODERATOR
 bbb_guestpolicy: ALWAYS_ACCEPT

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -19,6 +19,12 @@
     state: restarted
   become: true
 
+- name: restart kurento
+  systemd:
+    name: kurento-media-server
+    state: restarted
+  become: true
+
 - name: restart mongo
   service:
     name: mongod

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -284,6 +284,42 @@
   - restart freeswitch
   - reload nginx
 
+- name: change FreeSWITCH RTP start port
+  lineinfile:
+    path: /opt/freeswitch/conf/autoload_configs/switch.conf.xml
+    regexp: '<param name="rtp-start-port" value="[0-9]+"/>'
+    line: '<param name="rtp-start-port" value="{{ bbb_freeswitch_rtp_start_port }}"/>'
+  notify:
+  - restart freeswitch
+  - reload nginx
+
+- name: change FreeSWITCH RTP end port
+  lineinfile:
+    path: /opt/freeswitch/conf/autoload_configs/switch.conf.xml
+    regexp: '<param name="rtp-end-port" value="[0-9]+"/>'
+    line: '<param name="rtp-end-port" value="{{ bbb_freeswitch_rtp_end_port }}"/>'
+  notify:
+  - restart freeswitch
+  - reload nginx
+
+- name: change Kurento RTP start port
+  lineinfile:
+    path: /etc/kurento/modules/kurento/BaseRtpEndpoint.conf.ini
+    regexp: 'minPort=[0-9]+'
+    line: 'minPort={{ bbb_kurento_rtp_start_port }}'
+  notify:
+  - restart kurento
+  - reload nginx
+
+- name: change Kurento RTP end port
+  lineinfile:
+    path: /etc/kurento/modules/kurento/BaseRtpEndpoint.conf.ini
+    regexp: 'maxPort=[0-9]+'
+    line: 'maxPort={{ bbb_kurento_rtp_end_port }}'
+  notify:
+  - restart kurento
+  - reload nginx
+
 - name: FreeSWITCH dialplan quality
   replace:
     path: /opt/freeswitch/conf/dialplan/default/bbb_conference.xml


### PR DESCRIPTION
This allows to change the RTP ports from the supplied defaults. I needed this because some of the ports on the external IP were already in use by a different service and the default port range is way too big for my needs.