### PR TITLE
Fix FreeSWITCH IPv6 support

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -193,12 +193,28 @@
     content: '{{ meteor  | to_nice_yaml }}'
     dest: /usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml
 
-- name: configure freeswitch to use SSL
+- name: configure freeswitch to use SSL (IPv4 only)
   lineinfile:
     path: /etc/bigbluebutton/nginx/sip.nginx
     regexp: "proxy_pass"
     line: "        proxy_pass https://{{ ansible_default_ipv4.address }}:7443;"
   notify: reload nginx
+  when: not bbb_freeswitch_ipv6 | bool
+
+- name: configure freeswitch to use SSL (IPv4 + IPv6)
+  lineinfile:
+    path: /etc/bigbluebutton/nginx/sip.nginx
+    regexp: "proxy_pass"
+    line: "        proxy_pass https://$freeswitch_addr:7443;"
+  notify: reload nginx
+  when: bbb_freeswitch_ipv6 | bool
+
+- name: configure freeswitch external IP addresses
+  template:
+    src: bbb/bigbluebutton_sip_addr_map.conf.j2
+    dest: /etc/nginx/conf.d/bigbluebutton_sip_addr_map.conf
+  notify: reload nginx
+  when: bbb_freeswitch_ipv6 | bool
 
 - name: create ssl folder for nginx
   file:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -254,7 +254,7 @@
   - restart freeswitch
   - reload systemd
 
-- name: enable IPv6 in FreeSWITCH service 1/2
+- name: enable IPv6 in FreeSWITCH service 1/3
   command:
     cmd: mv {{ item }}_ {{ item }}
     creates: "{{ item }}"
@@ -267,11 +267,21 @@
   - restart freeswitch
   - reload nginx
 
-- name: enable IPv6 in FreeSWITCH service 2/2
+- name: enable IPv6 in FreeSWITCH service 2/3
   lineinfile:
     path: /opt/freeswitch/etc/freeswitch/autoload_configs/event_socket.conf.xml
     regexp: '<param name="listen-ip" value="[a-fA-F0-9.:]+"/>'
     line: '<param name="listen-ip" value="::"/>'
+  when: bbb_freeswitch_ipv6 | bool
+  notify:
+  - restart freeswitch
+  - reload nginx
+
+- name: enable IPv6 in FreeSWITCH service 3/3
+  lineinfile:
+    path: /opt/freeswitch/etc/freeswitch/sip_profiles/external-ipv6.xml
+    regexp: '^.*<param name="enable-3pcc" value="[a-zA-Z]+"/>.*$'
+    line: '    <param name="enable-3pcc" value="proxy"/>'
   when: bbb_freeswitch_ipv6 | bool
   notify:
   - restart freeswitch

--- a/templates/bbb/bigbluebutton_sip_addr_map.conf.j2
+++ b/templates/bbb/bigbluebutton_sip_addr_map.conf.j2
@@ -1,0 +1,4 @@
+map $remote_addr $freeswitch_addr {
+    "~:"    [{{ ansible_default_ipv6.address }}];
+    default    {{ ansible_default_ipv4.address }};
+}


### PR DESCRIPTION
It is not enough that freeswitch listens on ipv6, we must redirect incoming ipv6 packets to freeswitch via ipv6 also.
See documentation https://docs.bigbluebutton.org/2.2/troubleshooting#configure-bigbluebuttonfreeswitch-to-support-ipv6