### PR TITLE
Set default kurento listenting interface to ansible_default_ipv4.interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Also check [Before you install](https://docs.bigbluebutton.org/2.2/install.html#
 | `bbb_freeswitch_ioschedule_realtime` | [IOSchedulingClass](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#IOSchedulingClass=) | `true` | Set this to `false` for LXD/LXC Compatibility |
 | `bbb_freeswitch_ipv6` | Enable IPv6 support in FreeSWITCH | `true` | Disable to fix [FreeSWITCH IPv6 error][bbb_freeswitch_ipv6] |
 | `bbb_freeswitch_external_ip` | Set stun server for sip and rtp on FreeSWITCH | `stun:{{ (bbb_stun_servers \| first).server }}` | WARNING: the value of the default freeswitch installation is `stun:stun.freeswitch.org` |
+| `bbb_kurento_interfaces` | Specify the listening interfaces for kurento | `{{ [ansible_default_ipv4.interface, 'lo'] }}`
 | `bbb_dialplan_quality` | Set quality of dailplan for FreeSWITCH | `cdquality` |
 | `bbb_dialplan_energy_level` | Set energy level of dailplan for FreeSWITCH | `100` | only for selected profile `bbb_dialplan_quality`
 | `bbb_dialplan_comfort_noise` | Set comfort noise of dailplan for FreeSWITCH | `1400` | only for selected profile `bbb_dialplan_quality`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,6 +46,10 @@ bbb_freeswitch_ioschedule_realtime: true
 bbb_freeswitch_ipv6: true
 bbb_freeswitch_external_ip: "stun:{{ (bbb_stun_servers | first).server }}"
 
+bbb_kurento_interfaces:
+- "{{ ansible_default_ipv4.interface }}"
+- lo
+
 # ALWAYS_ACCEPT, ALWAYS_DENY, ASK_MODERATOR
 bbb_guestpolicy: ALWAYS_ACCEPT
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -19,6 +19,12 @@
     state: restarted
   become: true
 
+- name: restart kurento
+  service:
+    name: kurento-media-server
+    state: restarted
+  become: true
+
 - name: restart mongo
   service:
     name: mongod

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -342,6 +342,24 @@
   - restart freeswitch
   - reload nginx
 
+- name: kurento only listen on specified interfaces
+  replace:
+    path: /etc/kurento/modules/kurento/WebRtcEndpoint.conf.ini
+    regexp: '^;?networkInterfaces=.*$'
+    replace: 'networkInterfaces={{ bbb_kurento_interfaces | join(",") }}'
+  when: (bbb_kurento_interfaces | default([]) | length) > 0
+  notify: restart kurento
+  tags: debug
+
+- name: kurento listen on all interfaces
+  replace:
+    path: /etc/kurento/modules/kurento/WebRtcEndpoint.conf.ini
+    regexp: '^;?networkInterfaces=.*$'
+    replace: ';networkInterfaces='
+  when: (bbb_kurento_interfaces | default([]) | length) == 0
+  notify: restart kurento
+  tags: debug
+
 - name: set nodejs options for the html5-webclient
   replace:
     path: /usr/share/meteor/bundle/systemd_start.sh


### PR DESCRIPTION
Also adds lo because it may choose it when you have added your external address to the lo interface
Fixes #94