### PR TITLE
allows to disable SMTP SSL certificate valaidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ In that case, make sure the rest of the variables are properly set.
 
 The default value for `bbb_greenlight_smtp.sender` is `bbb@{{ bbb_hostname }}`
 
+To skip SSL certificate validation set `bbb_greenlight_smtp.openssl_verify_none` to `true`.
+
 Example Setup:
 ```yaml
 bbb_greenlight_smtp:

--- a/templates/greenlight/env.j2
+++ b/templates/greenlight/env.j2
@@ -127,6 +127,9 @@ ALLOW_MAIL_NOTIFICATIONS={{ bbb_allow_mail_notifications | ternary("true", "fals
 # Please note that enable this presents its own security risks and should not be done unless necessary.
 #   SMTP_OPENSSL_VERIFY_MODE=none
 #
+{% if bbb_greenlight_smtp.openssl_verify_none  %}
+SMTP_OPENSSL_VERIFY_MODE=none
+{% endif %}
 SMTP_SERVER={{ bbb_greenlight_smtp.server | default('') }}
 SMTP_PORT={{ bbb_greenlight_smtp.port | default('') }}
 SMTP_DOMAIN={{ bbb_greenlight_smtp.domain | default('') }}


### PR DESCRIPTION
Allows to disable SMTP SSL certificate valaidation.
This is needed to use a local MTA on the host machine for mail delivery.