### PR TITLE
configure freeswitch wss IP binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Also check [Before you install](https://docs.bigbluebutton.org/2.2/install.html#
 | `bbb_cpuschedule` | CPUSchedulingPolicy | `true` | Disable to fix [FreeSWITCH SETSCHEDULER error][bbb_cpuschedule], needed for LXD/LXC Compatibility |
 | `bbb_freeswitch_ioschedule_realtime` | [IOSchedulingClass](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#IOSchedulingClass=) | `true` | Set this to `false` for LXD/LXC Compatibility |
 | `bbb_freeswitch_ipv6` | Enable IPv6 support in FreeSWITCH | `true` | Disable to fix [FreeSWITCH IPv6 error][bbb_freeswitch_ipv6] |
+| `bbb_freeswitch_ip_address` | Set IP address for FreeSWITCH's wss-binding | `{{ ansible_default_ipv4.address }}` |
 | `bbb_freeswitch_external_ip` | Set stun server for sip and rtp on FreeSWITCH | `stun:{{ (bbb_stun_servers \| first).server }}` | WARNING: the value of the default freeswitch installation is `stun:stun.freeswitch.org` |
 | `bbb_dialplan_quality` | Set quality of dailplan for FreeSWITCH | `cdquality` |
 | `bbb_dialplan_energy_level` | Set energy level of dailplan for FreeSWITCH | `100` | only for selected profile `bbb_dialplan_quality`

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Also check [Before you install](https://docs.bigbluebutton.org/2.2/install.html#
 | `bbb_cpuschedule` | CPUSchedulingPolicy | `true` | Disable to fix [FreeSWITCH SETSCHEDULER error][bbb_cpuschedule], needed for LXD/LXC Compatibility |
 | `bbb_freeswitch_ioschedule_realtime` | [IOSchedulingClass](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#IOSchedulingClass=) | `true` | Set this to `false` for LXD/LXC Compatibility |
 | `bbb_freeswitch_ipv6` | Enable IPv6 support in FreeSWITCH | `true` | Disable to fix [FreeSWITCH IPv6 error][bbb_freeswitch_ipv6] |
-| `bbb_freeswitch_ip_address` | Set IP address for FreeSWITCH's wss-binding | `{{ ansible_default_ipv4.address }}` |
+| `bbb_freeswitch_ip_address` | Set IP address for FreeSWITCH's wss-binding | `{{ ansible_default_ipv4.address }}` | Can be used when port 7443 is already in use on `{{ ansible_default_ipv4.address }}` or in IPv6-only setups. |
 | `bbb_freeswitch_external_ip` | Set stun server for sip and rtp on FreeSWITCH | `stun:{{ (bbb_stun_servers \| first).server }}` | WARNING: the value of the default freeswitch installation is `stun:stun.freeswitch.org` |
 | `bbb_dialplan_quality` | Set quality of dailplan for FreeSWITCH | `cdquality` |
 | `bbb_dialplan_energy_level` | Set energy level of dailplan for FreeSWITCH | `100` | only for selected profile `bbb_dialplan_quality`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,6 +44,7 @@ bbb_nodejs_version: 8.x
 bbb_cpuschedule: true
 bbb_freeswitch_ioschedule_realtime: true
 bbb_freeswitch_ipv6: true
+bbb_freeswitch_ip_address: "{{ ansible_default_ipv4.address }}"
 bbb_freeswitch_external_ip: "stun:{{ (bbb_stun_servers | first).server }}"
 
 # ALWAYS_ACCEPT, ALWAYS_DENY, ASK_MODERATOR

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -238,7 +238,7 @@
   - restart freeswitch
   - reload systemd
 
-- name: configure wss-binding of FreeSWITCH
+- name: configure IP {{ bbb_freeswitch_ip_address }} for wss-binding of FreeSWITCH
   lineinfile:
     path: /opt/freeswitch/conf/sip_profiles/external.xml
     regexp: "<param name=\"wss-binding\"  value=\":7443\"/>"

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -197,7 +197,7 @@
   lineinfile:
     path: /etc/bigbluebutton/nginx/sip.nginx
     regexp: "proxy_pass"
-    line: "        proxy_pass https://{{ ansible_default_ipv4.address }}:7443;"
+    line: "        proxy_pass https://{{ bbb_freeswitch_ip_address }}:7443;"
   notify: reload nginx
 
 - name: create ssl folder for nginx
@@ -238,11 +238,11 @@
   - restart freeswitch
   - reload systemd
 
-- name: configure freeswitch to use correct IP address for wss-binding
+- name: configure wss-binding of FreeSWITCH
   lineinfile:
     path: /opt/freeswitch/conf/sip_profiles/external.xml
     regexp: "<param name=\"wss-binding\"  value=\":7443\"/>"
-    line: "    <param name=\"wss-binding\"  value=\"{{ ansible_default_ipv4.address }}:7443\"/>"
+    line: "    <param name=\"wss-binding\"  value=\"{{ bbb_freeswitch_ip_address }}:7443\"/>"
   notify: restart freeswitch
 
 - name: enable IPv6 in FreeSWITCH service 1/2

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -241,7 +241,7 @@
 - name: configure IP {{ bbb_freeswitch_ip_address }} for wss-binding of FreeSWITCH
   lineinfile:
     path: /opt/freeswitch/conf/sip_profiles/external.xml
-    regexp: "<param name=\"wss-binding\"  value=\":7443\"/>"
+    regexp: "<param name=\"wss-binding\"  value=\""
     line: "    <param name=\"wss-binding\"  value=\"{{ bbb_freeswitch_ip_address }}:7443\"/>"
   notify: restart freeswitch
 

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -238,6 +238,13 @@
   - restart freeswitch
   - reload systemd
 
+- name: configure freeswitch to use correct IP address for wss-binding
+  lineinfile:
+    path: /opt/freeswitch/conf/sip_profiles/external.xml
+    regexp: "<param name=\"wss-binding\"  value=\":7443\"/>"
+    line: "    <param name=\"wss-binding\"  value=\"{{ ansible_default_ipv4.address }}:7443\"/>"
+  notify: restart freeswitch
+
 - name: enable IPv6 in FreeSWITCH service 1/2
   command:
     cmd: mv {{ item }}_ {{ item }}


### PR DESCRIPTION
This PR makes sure that the freeswitch wss-binding is the same IP adress the nginx tries to connect to.

Reason for this PR:
In our environment, each server has two network interfaces (one configured with a private and the other one with a public ip address).
The nginx tried to connect to freeswitch on [public ip]:7443 (configured in line 200) while the freeswitch was listening on [private ip]:7443.
Therefore, users could not connect to the websocket and received Error 1002 in BBB.