### PR TITLE
Implement bbb_api_demos_enable variable

### DIFF
--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -27,6 +27,21 @@
   when: bbb_webhooks_enable
   notify: restart bigbluebutton
 
+- name: install bbb api demos
+  apt:
+    name: "{{ bbb_demos }}"
+    state: "{{ bbb_state }}"
+  when: bbb_api_demos_enable
+
+- name: remove bbb api demos
+  apt:
+    name: "{{ bbb_demos }}"
+    state: "absent"
+    # Using autoremove because otherwise tomcat8
+    # would stay installed and keep running
+    autoremove: true
+  when: not bbb_api_demos_enable
+
 - name: upgrade packages
   apt:
     upgrade: "{{ bbb_upgrade_packages }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -20,3 +20,6 @@ bbb_and_dependencies:
 
 bbb_webhooks:
   - bbb-webhooks
+
+bbb_demos:
+  - bbb-demo


### PR DESCRIPTION
Currently the variable `bbb_api_demos_enable` is listed in the README,
however it is not used in the playbook. Practically, the `bbb-demo`
package is not installed and the API demo is not working.

This PR adds support for the installation and, quite importantly,
removal of the `bbb-demo` apt package.
