### PR TITLE
docs: change links to 2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 > Ansible role for a BigBlueButton installation
 
-This role is following the documentation on <https://docs.bigbluebutton.org/2.2/install.html>
+This role is following the documentation on <https://docs.bigbluebutton.org/2.3/install.html>
 
-Also check [Before you install](https://docs.bigbluebutton.org/2.2/install.html#before-you-install) and [Minimum server requirements](https://docs.bigbluebutton.org/2.2/install.html#minimum-server-requirements) from the official documentation as they also apply here.
+Also check [Before you install](https://docs.bigbluebutton.org/2.3/install.html#before-you-install) and [Minimum server requirements](https://docs.bigbluebutton.org/2.3/install.html#minimum-server-requirements) from the official documentation as they also apply here.
 
 ## Role Variables
 


### PR DESCRIPTION
There are also the following two references to 2.2 but I'm not entirely sure what to do with them. The troubleshooting page doesnt exist (yet) for 2.3.

https://github.com/ebbba-org/ansible-role-bigbluebutton/blob/7900bc196a028e2f899b47d7a0461573e439f58b/README.md#L340

https://github.com/ebbba-org/ansible-role-bigbluebutton/blob/7900bc196a028e2f899b47d7a0461573e439f58b/tasks/config.yml#L264