### PR TITLE
Add bbb-conf package dependency net-tools

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -12,6 +12,7 @@ bbb_required_packages:
   - openjdk-8-jdk
   - python3-passlib
   - python-passlib
+  - net-tools
 
 bbb_and_dependencies:
   - mongodb-org


### PR DESCRIPTION
This packages install the missing tools required by bbb-conf: route,
ifconfig and netstat

```
/usr/bin/bbb-conf: line 884: netstat: command not found
/usr/bin/bbb-conf: line 203: ifconfig: command not found
/usr/bin/bbb-conf: line 206: route: command not found
/usr/bin/bbb-conf: line 206: ifconfig: command not found
/usr/bin/bbb-conf: line 1231: netstat: command not found
```