### PR TITLE
Add sip_ip and ip for freeswitch to kurento defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -151,6 +151,8 @@ bbb_webrtc_sfu_multikurento:
         request_timeout: 30000
         response_timeout: 30000
   freeswitch:
+    sip_ip: "{{ ansible_default_ipv4.address }}"
+    ip: "{{ ansible_default_ipv4.address }}"
     esl_password: "{{ bbb_freeswitch_socket_password }}"
   log:
     level: warn


### PR DESCRIPTION
See https://github.com/ebbba-org/ansible-role-bigbluebutton/issues/113#issuecomment-843170666 for extended discussion

The reason for this PR is that sometimes the wrong IP is used inside the default kurento/webrtc config.

This override is also implemented by the bbb-install script: [sip_ip here](https://github.com/bigbluebutton/bbb-install/blob/856c5da3e62552fe218f0fb4cd23c0bd7eb65b25/bbb-install.sh#L997) and [ip here](https://github.com/bigbluebutton/bbb-install/blob/856c5da3e62552fe218f0fb4cd23c0bd7eb65b25/bbb-install.sh#L987)