### PR TITLE
Upgrade pip to latest version

### DIFF
--- a/tasks/certificate-selfsigned.yml
+++ b/tasks/certificate-selfsigned.yml
@@ -23,6 +23,11 @@
     force: true
   when: bbb_own_key is defined
 
+- name: upgrade pip to latest version
+  pip: 
+    name: pip
+    state: latest
+
 - name: Ensure openssl-python-module is installed
   pip:
     name: PyOpenSSL


### PR DESCRIPTION
Upgrade pip to fix following error:
```
TASK [bbb_23 : Ensure openssl-python-module is installed] ************************************************************************************************************************************************************************************
fatal: [bbb.example.com]: FAILED! => {"changed": false, "cmd": ["/usr/bin/pip3", "install", "-U", "PyOpenSSL"], "msg": "stdout: Collecting PyOpenSSL\n  Using cached https://files.pythonhosted.org/packages/b2/5e/06351ede29fd4899782ad335c2e02f1f862a887c20a3541f17c3fa1a3525/pyOpenSSL-20.0.1-py2.py3-none-any.whl\nCollecting six>=1.5.2 (from PyOpenSSL)\n  Using cached https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl\nCollecting cryptography>=3.2 (from PyOpenSSL)\n  Using cached https://files.pythonhosted.org/packages/9b/77/461087a514d2e8ece1c975d8216bc03f7048e6090c5166bc34115afdaa53/cryptography-3.4.7.tar.gz\n    Complete output from command python setup.py egg_info:\n    Traceback (most recent call last):\n      File \"<string>\", line 1, in <module>\n      File \"/tmp/pip-build-q3ee_aql/cryptography/setup.py\", line 14, in <module>\n        from setuptools_rust import RustExtension\n    ModuleNotFoundError: No module named 'setuptools_rust'\n    \n            =============================DEBUG ASSISTANCE==========================\n            If you are seeing an error here please try the following to\n            successfully install cryptography:\n    \n            Upgrade to the latest pip and try again. This will fix errors for most\n            users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip\n            =============================DEBUG ASSISTANCE==========================\n    \n    \n    ----------------------------------------\n\n:stderr: Command \"python setup.py egg_info\" failed with error code 1 in /tmp/pip-build-q3ee_aql/cryptography/\n"}
```