### PR TITLE
Fix conditional vars in docker_login task

### DIFF
--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -18,4 +18,4 @@
   docker_login:
     username: "{{ bbb_docker_user }}"
     password: "{{ bbb_docker_passwd }}"
-  when: bbb_docker_user and bbb_docker_passwd
+  when: bbb_docker_user|default(None) and bbb_docker_passwd|default(None)


### PR DESCRIPTION
Error: error while evaluating conditional (bbb_docker_user and
bbb_docker_passwd): 'bbb_docker_user' is undefined