### PR TITLE
Added bigbluebutton-exporter as Systemd service

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Also check [Before you install](https://docs.bigbluebutton.org/2.3/install.html#
 | `bbb_monitoring_all_in_one_htpasswd_user` | The user for the htpasswd - _(required)_ if external | `Undefined` | |
 | `bbb_monitoring_all_in_one_htpasswd` | The password for the htpasswd - _(required)_ if external | `Undefined` | |
 | `bbb_monitoring_recordings_from_disk` | Collect recordings metrics by querying the disk instead of the API. See [this](https://bigbluebutton-exporter.greenstatic.dev/exporter-user-guide/#optimizations) for details. | `true` |
-| `bbb_monitoring_systemd_enable` | Deploy monitoring as systemd service(not recommended) | `false` | Works only when `bbb_monitoring_all_in_one_enable` is `false` |
+| `bbb_monitoring_systemd_enable` | Deploy monitoring as systemd service (not recommended) | `false` | Works only when `bbb_monitoring_all_in_one_enable` is `false` |
 | `bbb_monitoring_systemd_version` | Version of the (greenstatic/bigbluebutton-exporter)[https://github.com/greenstatic/bigbluebutton-exporter] | `HEAD` | Could be a branch or tag |
 | `bbb_monitoring_systemd_directory` | Installation directory for git repository | `"/opt/bigbluebutton-exporter"` | |
 | `bbb_monitoring_systemd_external` | Enable exposure to nginx | `false` | |

--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ Also check [Before you install](https://docs.bigbluebutton.org/2.3/install.html#
 | `bbb_monitoring_all_in_one_port` | Internal Port for the monitoring werbservice | `3001` | |
 | `bbb_monitoring_all_in_one_grafana` | Enable(true)/Disable(false) the Grafana container | `true` | |
 | `bbb_monitoring_all_in_one_prometheus` | Enable(true)/Disable(false) the prometheus container | `true` | |
-| `bbb_monitoring_all_in_one_external` | Deprecated, use `bbb_monitoring_exporter_external` instead | | Can be reached under `/mon/bbb` and `/mon/node` - requires `htpasswd` and `htpasswd_user` |
-| `bbb_monitoring_all_in_one_htpasswd_user` | Deprecated, use `bbb_monitoring_exporter_htpasswd_user` instead | | |
-| `bbb_monitoring_all_in_one_htpasswd` | Deprecated, use `bbb_monitoring_exporter_htpasswd` instead | | |
+| `bbb_monitoring_all_in_one_external` | Deprecated, use `bbb_monitoring_external` instead | | Can be reached under `/mon/bbb` and `/mon/node` - requires `htpasswd` and `htpasswd_user` |
+| `bbb_monitoring_all_in_one_htpasswd_user` | Deprecated, use `bbb_monitoring_htpasswd_user` instead | | |
+| `bbb_monitoring_all_in_one_htpasswd` | Deprecated, use `bbb_monitoring_htpasswd` instead | | |
 | `bbb_monitoring_recordings_from_disk` | Collect recordings metrics by querying the disk instead of the API. See [this](https://bigbluebutton-exporter.greenstatic.dev/exporter-user-guide/#optimizations) for details. | `true` |
-| `bbb_monitoring_exporter_external` | Enable exposure to nginx | `false` | Can be reached under `/mon/bbb` and `/mon/node` - requires `htpasswd` and `htpasswd_user`. If `bbb_monitoring_systemd_enable` is enabled, no Node Exporter installation process is included |
-| `bbb_monitoring_exporter_htpasswd_user` | The user for the htpasswd - _(required)_ if external | `Undefined` | |
-| `bbb_monitoring_exporter_htpasswd` | The password for the htpasswd - _(required)_ if external | `Undefined` | |
+| `bbb_monitoring_external` | Enable exposure to nginx | `false` | Can be reached under `/mon/bbb` and `/mon/node` - requires `htpasswd` and `htpasswd_user`. If `bbb_monitoring_systemd_enable` is enabled, no Node Exporter installation process is included |
+| `bbb_monitoring_htpasswd_user` | The user for the htpasswd - _(required)_ if external | `Undefined` | |
+| `bbb_monitoring_htpasswd` | The password for the htpasswd - _(required)_ if external | `Undefined` | |
 | `bbb_monitoring_exporter_version` | Version of the BigBlueButton Exporter for docker and systemd | `latest` if docker image is enabled or `HEAD` if systemd is enabled | If `bbb_monitoring_all_in_one_enable` is enabled, the [Docker images tags](https://hub.docker.com/r/greenstatic/bigbluebutton-exporter/tags?page=1&ordering=last_updated) can be used. If `bbb_monitoring_systemd_enable` is enabled, the [Git release tags](https://github.com/greenstatic/bigbluebutton-exporter/releases) can be used. |
 | `bbb_monitoring_systemd_enable` | Deploy monitoring as systemd service (not recommended) | `false` | Works only when `bbb_monitoring_all_in_one_enable` is `false` |
 | `bbb_monitoring_systemd_directory` | Installation directory for git repository | `"/opt/bigbluebutton-exporter"` | |

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Also check [Before you install](https://docs.bigbluebutton.org/2.3/install.html#
 | `bbb_monitoring_recordings_from_disk` | Collect recordings metrics by querying the disk instead of the API. See [this](https://bigbluebutton-exporter.greenstatic.dev/exporter-user-guide/#optimizations) for details. | `true` |
 | `bbb_monitoring_systemd_enable` | Deploy monitoring as systemd service(not recommended) | `false` | Works only when `bbb_monitoring_all_in_one_enable` is `false` |
 | `bbb_monitoring_systemd_version` | Version of the (greenstatic/bigbluebutton-exporter)[https://github.com/greenstatic/bigbluebutton-exporter] | `HEAD` | Could be a branch or tag |
-| `bbb_monitoring_systemd_directory` | Installation directory for git repository | `"/opt/bbb-exporter"` | |
+| `bbb_monitoring_systemd_directory` | Installation directory for git repository | `"/opt/bigbluebutton-exporter"` | |
 | `bbb_monitoring_systemd_external` | Enable exposure to nginx | `false` | |
 | `bbb_dialin_enabled` | enable phone dial-in, will also remove any previous dial-in configuration if set to `false`  | `false` | |
 | `bbb_dialin_provider_proxy` | IP or Domain of your SIP provider, also known as registrar | `sip.example.net` | |

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Also check [Before you install](https://docs.bigbluebutton.org/2.3/install.html#
 | `bbb_dialplan_comfort_noise` | Set comfort noise of dailplan for FreeSWITCH | `1400` | only for selected profile `bbb_dialplan_quality` |
 | `bbb_webhooks_enable` | install bbb-webhooks | `no` | |
 | `bbb_monitoring_all_in_one_enable` | deploy [all in one monitoring stack](https://bigbluebutton-exporter.greenstatic.dev/installation/all_in_one_monitoring_stack/) (docker) | `no` |
-| `bbb_monitoring_all_in_one_version` | Version of the `greenstatic/bigbluebutton-exporter` docker image | `{{ bbb_monitoring_exporter_version }}` |  |
+| `bbb_monitoring_all_in_one_version` | Deprecated, use `bbb_monitoring_exporter_version` instead | | |
 | `bbb_monitoring_all_in_one_directory` | Directory for the docker compose files | `/root/bbb-monitoring` | |
 | `bbb_monitoring_all_in_one_port` | Internal Port for the monitoring werbservice | `3001` | |
 | `bbb_monitoring_all_in_one_grafana` | Enable(true)/Disable(false) the Grafana container | `true` | |
@@ -81,7 +81,7 @@ Also check [Before you install](https://docs.bigbluebutton.org/2.3/install.html#
 | `bbb_monitoring_exporter_version` | Version of the BigBlueButton Exporter for docker and systemd | `latest` if docker image is enabled or `HEAD` if systemd is enabled | If `bbb_monitoring_all_in_one_enable` is enabled, the [Docker images tags](https://hub.docker.com/r/greenstatic/bigbluebutton-exporter/tags?page=1&ordering=last_updated) can be used. If `bbb_monitoring_systemd_enable` is enabled, the [Git release tags](https://github.com/greenstatic/bigbluebutton-exporter/releases) can be used. |
 | `bbb_monitoring_systemd_enable` | Deploy monitoring as systemd service (not recommended) | `false` | Works only when `bbb_monitoring_all_in_one_enable` is `false` |
 | `bbb_monitoring_systemd_directory` | Installation directory for git repository | `"/opt/bigbluebutton-exporter"` | |
-| `bbb_monitoring_systemd_external` | Enable exposure to nginx | `false` | For the external accessibility the variables `bbb_monitoring_all_in_one_htpasswd_user` and `bbb_monitoring_all_in_one_htpasswd` have to be set |
+| `bbb_monitoring_systemd_external` | Enable exposure to nginx | `false` | For the external accessibility the variables `bbb_monitoring_all_in_one_htpasswd_user` and `bbb_monitoring_all_in_one_htpasswd` have to be set. No Node Exporter installation process included |
 | `bbb_monitoring_systemd_port` | Port of bbb-exporter | `9688` | default port 9866 is defined by the exporter [itself](https://github.com/greenstatic/bigbluebutton-exporter/blob/master/bbb-exporter/settings.py#L37) |
 | `bbb_monitoring_systemd_bind_ip` | Port of bbb-exporter | `0.0.0.0` | default bind IP 0.0.0.0 is defined by the exporter [itself](https://github.com/greenstatic/bigbluebutton-exporter/blob/master/bbb-exporter/settings.py#L38) |
 | `bbb_dialin_enabled` | enable phone dial-in, will also remove any previous dial-in configuration if set to `false`  | `false` | |

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Also check [Before you install](https://docs.bigbluebutton.org/2.3/install.html#
 | `bbb_dialplan_comfort_noise` | Set comfort noise of dailplan for FreeSWITCH | `1400` | only for selected profile `bbb_dialplan_quality` |
 | `bbb_webhooks_enable` | install bbb-webhooks | `no` | |
 | `bbb_monitoring_all_in_one_enable` | deploy [all in one monitoring stack](https://bigbluebutton-exporter.greenstatic.dev/installation/all_in_one_monitoring_stack/) (docker) | `no` |
-| `bbb_monitoring_all_in_one_version` | Version of the `greenstatic/bigbluebutton-exporter` docker image | `latest` | |
+| `bbb_monitoring_all_in_one_version` | Version of the `greenstatic/bigbluebutton-exporter` docker image | `{{ bbb_monitoring_exporter_version }}` |  |
 | `bbb_monitoring_all_in_one_directory` | Directory for the docker compose files | `/root/bbb-monitoring` | |
 | `bbb_monitoring_all_in_one_port` | Internal Port for the monitoring werbservice | `3001` | |
 | `bbb_monitoring_all_in_one_grafana` | Enable(true)/Disable(false) the Grafana container | `true` | |
@@ -78,8 +78,8 @@ Also check [Before you install](https://docs.bigbluebutton.org/2.3/install.html#
 | `bbb_monitoring_all_in_one_htpasswd_user` | The user for the htpasswd - _(required)_ if external | `Undefined` | |
 | `bbb_monitoring_all_in_one_htpasswd` | The password for the htpasswd - _(required)_ if external | `Undefined` | |
 | `bbb_monitoring_recordings_from_disk` | Collect recordings metrics by querying the disk instead of the API. See [this](https://bigbluebutton-exporter.greenstatic.dev/exporter-user-guide/#optimizations) for details. | `true` |
+| `bbb_monitoring_exporter_version` | Version of the BigBlueButton Exporter for docker and systemd | `latest` if docker image is enabled or `HEAD` if systemd is enabled | If `bbb_monitoring_all_in_one_enable` is enabled, the [Docker images tags](https://hub.docker.com/r/greenstatic/bigbluebutton-exporter/tags?page=1&ordering=last_updated) can be used. If `bbb_monitoring_systemd_enable` is enabled, the [Git release tags](https://github.com/greenstatic/bigbluebutton-exporter/releases) can be used. |
 | `bbb_monitoring_systemd_enable` | Deploy monitoring as systemd service (not recommended) | `false` | Works only when `bbb_monitoring_all_in_one_enable` is `false` |
-| `bbb_monitoring_systemd_version` | Version of the (greenstatic/bigbluebutton-exporter)[https://github.com/greenstatic/bigbluebutton-exporter] | `HEAD` | Could be a branch or tag |
 | `bbb_monitoring_systemd_directory` | Installation directory for git repository | `"/opt/bigbluebutton-exporter"` | |
 | `bbb_monitoring_systemd_external` | Enable exposure to nginx | `false` | For the external accessibility the variables `bbb_monitoring_all_in_one_htpasswd_user` and `bbb_monitoring_all_in_one_htpasswd` have to be set |
 | `bbb_monitoring_systemd_port` | Port of bbb-exporter | `9688` | default port 9866 is defined by the exporter [itself](https://github.com/greenstatic/bigbluebutton-exporter/blob/master/bbb-exporter/settings.py#L37) |

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Also check [Before you install](https://docs.bigbluebutton.org/2.3/install.html#
 | `bbb_monitoring_all_in_one_external` | Enable exposure to nginx | `false` | Can be reached under `/mon/bbb` and `/mon/node` - requires `htpasswd` and `htpasswd_user` |
 | `bbb_monitoring_all_in_one_htpasswd_user` | The user for the htpasswd - _(required)_ if external | `Undefined` | |
 | `bbb_monitoring_all_in_one_htpasswd` | The password for the htpasswd - _(required)_ if external | `Undefined` | |
-| `bbb_monitoring_all_in_one_recordings_from_disk` | Collect recordings metrics by querying the disk instead of the API. See [this](https://bigbluebutton-exporter.greenstatic.dev/exporter-user-guide/#optimizations) for details. | `true` |
+| `bbb_monitoring_recordings_from_disk` | Collect recordings metrics by querying the disk instead of the API. See [this](https://bigbluebutton-exporter.greenstatic.dev/exporter-user-guide/#optimizations) for details. | `true` |
 | `bbb_monitoring_systemd_enable` | Deploy monitoring as systemd service(not recommended) | `false` | Works only when `bbb_monitoring_all_in_one_enable` is `false` |
 | `bbb_monitoring_systemd_version` | Version of the (greenstatic/bigbluebutton-exporter)[https://github.com/greenstatic/bigbluebutton-exporter] | `HEAD` | Could be a branch or tag |
 | `bbb_monitoring_systemd_directory` | Installation directory for git repository | `"/opt/bbb-exporter"` | |

--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ Also check [Before you install](https://docs.bigbluebutton.org/2.3/install.html#
 | `bbb_monitoring_systemd_enable` | Deploy monitoring as systemd service (not recommended) | `false` | Works only when `bbb_monitoring_all_in_one_enable` is `false` |
 | `bbb_monitoring_systemd_version` | Version of the (greenstatic/bigbluebutton-exporter)[https://github.com/greenstatic/bigbluebutton-exporter] | `HEAD` | Could be a branch or tag |
 | `bbb_monitoring_systemd_directory` | Installation directory for git repository | `"/opt/bigbluebutton-exporter"` | |
-| `bbb_monitoring_systemd_external` | Enable exposure to nginx | `false` | |
+| `bbb_monitoring_systemd_external` | Enable exposure to nginx | `false` | For the external accessibility the variables `bbb_monitoring_all_in_one_htpasswd_user` and `bbb_monitoring_all_in_one_htpasswd` have to be set |
+| `bbb_monitoring_systemd_port` | Port of bbb-exporter | `9688` | default port 9866 is defined by the exporter [itself](https://github.com/greenstatic/bigbluebutton-exporter/blob/master/bbb-exporter/settings.py#L37) |
+| `bbb_monitoring_systemd_bind_ip` | Port of bbb-exporter | `0.0.0.0` | default bind IP 0.0.0.0 is defined by the exporter [itself](https://github.com/greenstatic/bigbluebutton-exporter/blob/master/bbb-exporter/settings.py#L38) |
 | `bbb_dialin_enabled` | enable phone dial-in, will also remove any previous dial-in configuration if set to `false`  | `false` | |
 | `bbb_dialin_provider_proxy` | IP or Domain of your SIP provider, also known as registrar | `sip.example.net` | |
 | `bbb_dialin_provider_username` | Username for authentication on the SIP-server | `provider-account` | |

--- a/README.md
+++ b/README.md
@@ -77,7 +77,11 @@ Also check [Before you install](https://docs.bigbluebutton.org/2.3/install.html#
 | `bbb_monitoring_all_in_one_external` | Enable exposure to nginx | `false` | Can be reached under `/mon/bbb` and `/mon/node` - requires `htpasswd` and `htpasswd_user` |
 | `bbb_monitoring_all_in_one_htpasswd_user` | The user for the htpasswd - _(required)_ if external | `Undefined` | |
 | `bbb_monitoring_all_in_one_htpasswd` | The password for the htpasswd - _(required)_ if external | `Undefined` | |
-| `bbb_monitoring_recordings_from_disk` | Collect recordings metrics by querying the disk instead of the API. See [this](https://bigbluebutton-exporter.greenstatic.dev/exporter-user-guide/#optimizations) for details. | `true` |
+| `bbb_monitoring_all_in_one_recordings_from_disk` | Collect recordings metrics by querying the disk instead of the API. See [this](https://bigbluebutton-exporter.greenstatic.dev/exporter-user-guide/#optimizations) for details. | `true` |
+| `bbb_monitoring_systemd_enable` | Deploy monitoring as systemd service(not recommended) | `false` | Works only when `bbb_monitoring_all_in_one_enable` is `false` |
+| `bbb_monitoring_systemd_version` | Version of the (greenstatic/bigbluebutton-exporter)[https://github.com/greenstatic/bigbluebutton-exporter] | `HEAD` | Could be a branch or tag |
+| `bbb_monitoring_systemd_directory` | Installation directory for git repository | `"/opt/bbb-exporter"` | |
+| `bbb_monitoring_systemd_external` | Enable exposure to nginx | `false` | |
 | `bbb_dialin_enabled` | enable phone dial-in, will also remove any previous dial-in configuration if set to `false`  | `false` | |
 | `bbb_dialin_provider_proxy` | IP or Domain of your SIP provider, also known as registrar | `sip.example.net` | |
 | `bbb_dialin_provider_username` | Username for authentication on the SIP-server | `provider-account` | |

--- a/README.md
+++ b/README.md
@@ -74,14 +74,16 @@ Also check [Before you install](https://docs.bigbluebutton.org/2.3/install.html#
 | `bbb_monitoring_all_in_one_port` | Internal Port for the monitoring werbservice | `3001` | |
 | `bbb_monitoring_all_in_one_grafana` | Enable(true)/Disable(false) the Grafana container | `true` | |
 | `bbb_monitoring_all_in_one_prometheus` | Enable(true)/Disable(false) the prometheus container | `true` | |
-| `bbb_monitoring_all_in_one_external` | Enable exposure to nginx | `false` | Can be reached under `/mon/bbb` and `/mon/node` - requires `htpasswd` and `htpasswd_user` |
-| `bbb_monitoring_all_in_one_htpasswd_user` | The user for the htpasswd - _(required)_ if external | `Undefined` | |
-| `bbb_monitoring_all_in_one_htpasswd` | The password for the htpasswd - _(required)_ if external | `Undefined` | |
+| `bbb_monitoring_all_in_one_external` | Deprecated, use `bbb_monitoring_exporter_external` instead | | Can be reached under `/mon/bbb` and `/mon/node` - requires `htpasswd` and `htpasswd_user` |
+| `bbb_monitoring_all_in_one_htpasswd_user` | Deprecated, use `bbb_monitoring_exporter_htpasswd_user` instead | | |
+| `bbb_monitoring_all_in_one_htpasswd` | Deprecated, use `bbb_monitoring_exporter_htpasswd` instead | | |
 | `bbb_monitoring_recordings_from_disk` | Collect recordings metrics by querying the disk instead of the API. See [this](https://bigbluebutton-exporter.greenstatic.dev/exporter-user-guide/#optimizations) for details. | `true` |
+| `bbb_monitoring_exporter_external` | Enable exposure to nginx | `false` | Can be reached under `/mon/bbb` and `/mon/node` - requires `htpasswd` and `htpasswd_user`. If `bbb_monitoring_systemd_enable` is enabled, no Node Exporter installation process is included |
+| `bbb_monitoring_exporter_htpasswd_user` | The user for the htpasswd - _(required)_ if external | `Undefined` | |
+| `bbb_monitoring_exporter_htpasswd` | The password for the htpasswd - _(required)_ if external | `Undefined` | |
 | `bbb_monitoring_exporter_version` | Version of the BigBlueButton Exporter for docker and systemd | `latest` if docker image is enabled or `HEAD` if systemd is enabled | If `bbb_monitoring_all_in_one_enable` is enabled, the [Docker images tags](https://hub.docker.com/r/greenstatic/bigbluebutton-exporter/tags?page=1&ordering=last_updated) can be used. If `bbb_monitoring_systemd_enable` is enabled, the [Git release tags](https://github.com/greenstatic/bigbluebutton-exporter/releases) can be used. |
 | `bbb_monitoring_systemd_enable` | Deploy monitoring as systemd service (not recommended) | `false` | Works only when `bbb_monitoring_all_in_one_enable` is `false` |
 | `bbb_monitoring_systemd_directory` | Installation directory for git repository | `"/opt/bigbluebutton-exporter"` | |
-| `bbb_monitoring_systemd_external` | Enable exposure to nginx | `false` | For the external accessibility the variables `bbb_monitoring_all_in_one_htpasswd_user` and `bbb_monitoring_all_in_one_htpasswd` have to be set. No Node Exporter installation process included |
 | `bbb_monitoring_systemd_port` | Port of bbb-exporter | `9688` | default port 9866 is defined by the exporter [itself](https://github.com/greenstatic/bigbluebutton-exporter/blob/master/bbb-exporter/settings.py#L37) |
 | `bbb_monitoring_systemd_bind_ip` | Port of bbb-exporter | `0.0.0.0` | default bind IP 0.0.0.0 is defined by the exporter [itself](https://github.com/greenstatic/bigbluebutton-exporter/blob/master/bbb-exporter/settings.py#L38) |
 | `bbb_dialin_enabled` | enable phone dial-in, will also remove any previous dial-in configuration if set to `false`  | `false` | |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -80,7 +80,7 @@ bbb_apt_key: 770C4267C5E63474D171B60937B5DD5EFAB46452
 ansible_python_interpreter: "/usr/bin/python3"
 
 bbb_monitoring_all_in_one_enable: false
-bbb_monitoring_all_in_one_version: latest
+bbb_monitoring_all_in_one_version: "{{ bbb_monitoring_exporter_version }}"
 bbb_monitoring_all_in_one_directory: "/root/bbb-monitoring"
 bbb_monitoring_all_in_one_port: 3001
 bbb_monitoring_recordings_from_disk: true
@@ -89,9 +89,9 @@ bbb_monitoring_all_in_one_prometheus: true
 bbb_monitoring_all_in_one_external: false
 # bbb_monitoring_all_in_one_htpasswd_user:
 # bbb_monitoring_all_in_one_htpasswd:
+bbb_monitoring_exporter_version: {{ 'latest' if bbb_monitoring_all_in_one_enable | bool else 'HEAD' }}
 
 bbb_monitoring_systemd_enable: false
-bbb_monitoring_systemd_version: HEAD
 bbb_monitoring_systemd_directory: "/opt/bigbluebutton-exporter"
 bbb_monitoring_systemd_external: false
 bbb_monitoring_systemd_bind_ip: 0.0.0.0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -86,13 +86,13 @@ bbb_monitoring_recordings_from_disk: true
 bbb_monitoring_all_in_one_grafana: true
 bbb_monitoring_all_in_one_prometheus: true
 bbb_monitoring_all_in_one_external: false
-# bbb_monitoring_all_in_one_htpasswd_user:
-# bbb_monitoring_all_in_one_htpasswd:
+# bbb_monitoring_exporter_htpasswd_user:
+# bbb_monitoring_exporter_htpasswd:
+bbb_monitoring_exporter_external: true
 bbb_monitoring_exporter_version: "{{ 'latest' if bbb_monitoring_all_in_one_enable | bool else 'HEAD' }}"
 
 bbb_monitoring_systemd_enable: false
 bbb_monitoring_systemd_directory: "/opt/bigbluebutton-exporter"
-bbb_monitoring_systemd_external: false
 bbb_monitoring_systemd_bind_ip: 0.0.0.0
 bbb_monitoring_systemd_port: 9688
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -89,7 +89,7 @@ bbb_monitoring_all_in_one_prometheus: true
 bbb_monitoring_all_in_one_external: false
 # bbb_monitoring_all_in_one_htpasswd_user:
 # bbb_monitoring_all_in_one_htpasswd:
-bbb_monitoring_exporter_version: {{ 'latest' if bbb_monitoring_all_in_one_enable | bool else 'HEAD' }}
+bbb_monitoring_exporter_version: "{{ 'latest' if bbb_monitoring_all_in_one_enable | bool else 'HEAD' }}"
 
 bbb_monitoring_systemd_enable: false
 bbb_monitoring_systemd_directory: "/opt/bigbluebutton-exporter"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -86,9 +86,9 @@ bbb_monitoring_recordings_from_disk: true
 bbb_monitoring_all_in_one_grafana: true
 bbb_monitoring_all_in_one_prometheus: true
 bbb_monitoring_all_in_one_external: false
-# bbb_monitoring_exporter_htpasswd_user:
-# bbb_monitoring_exporter_htpasswd:
-bbb_monitoring_exporter_external: true
+# bbb_monitoring_htpasswd_user:
+# bbb_monitoring_htpasswd:
+bbb_monitoring_external: true
 bbb_monitoring_exporter_version: "{{ 'latest' if bbb_monitoring_all_in_one_enable | bool else 'HEAD' }}"
 
 bbb_monitoring_systemd_enable: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -89,7 +89,7 @@ bbb_monitoring_all_in_one_prometheus: true
 bbb_monitoring_all_in_one_external: false
 # bbb_monitoring_htpasswd_user:
 # bbb_monitoring_htpasswd:
-bbb_monitoring_external: true
+bbb_monitoring_external: false
 bbb_monitoring_exporter_version: "{{ 'latest' if bbb_monitoring_all_in_one_enable | bool else 'HEAD' }}"
 
 bbb_monitoring_systemd_enable: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -83,7 +83,7 @@ bbb_monitoring_all_in_one_enable: false
 bbb_monitoring_all_in_one_version: latest
 bbb_monitoring_all_in_one_directory: "/root/bbb-monitoring"
 bbb_monitoring_all_in_one_port: 3001
-bbb_monitoring_all_in_one_recordings_from_disk: true
+bbb_monitoring_recordings_from_disk: true
 bbb_monitoring_all_in_one_grafana: true
 bbb_monitoring_all_in_one_prometheus: true
 bbb_monitoring_all_in_one_external: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -92,7 +92,7 @@ bbb_monitoring_all_in_one_external: false
 
 bbb_monitoring_systemd_enable: false
 bbb_monitoring_systemd_version: HEAD
-bbb_monitoring_systemd_directory: "/opt/bbb-exporter"
+bbb_monitoring_systemd_directory: "/opt/bigbluebutton-exporter"
 bbb_monitoring_systemd_external: false
 
 bbb_dialin_enabled: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -94,6 +94,8 @@ bbb_monitoring_systemd_enable: false
 bbb_monitoring_systemd_version: HEAD
 bbb_monitoring_systemd_directory: "/opt/bigbluebutton-exporter"
 bbb_monitoring_systemd_external: false
+bbb_monitoring_systemd_bind_ip: 0.0.0.0
+bbb_monitoring_systemd_port: 9688
 
 bbb_dialin_enabled: false
 bbb_dialin_provider_proxy: "sip.example.net"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -83,12 +83,17 @@ bbb_monitoring_all_in_one_enable: false
 bbb_monitoring_all_in_one_version: latest
 bbb_monitoring_all_in_one_directory: "/root/bbb-monitoring"
 bbb_monitoring_all_in_one_port: 3001
-bbb_monitoring_recordings_from_disk: true
+bbb_monitoring_all_in_one_recordings_from_disk: true
 bbb_monitoring_all_in_one_grafana: true
 bbb_monitoring_all_in_one_prometheus: true
 bbb_monitoring_all_in_one_external: false
 # bbb_monitoring_all_in_one_htpasswd_user:
 # bbb_monitoring_all_in_one_htpasswd:
+
+bbb_monitoring_systemd_enable: false
+bbb_monitoring_systemd_version: HEAD
+bbb_monitoring_systemd_directory: "/opt/bbb-exporter"
+bbb_monitoring_systemd_external: false
 
 bbb_dialin_enabled: false
 bbb_dialin_provider_proxy: "sip.example.net"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -80,7 +80,6 @@ bbb_apt_key: 770C4267C5E63474D171B60937B5DD5EFAB46452
 ansible_python_interpreter: "/usr/bin/python3"
 
 bbb_monitoring_all_in_one_enable: false
-bbb_monitoring_all_in_one_version: "{{ bbb_monitoring_exporter_version }}"
 bbb_monitoring_all_in_one_directory: "/root/bbb-monitoring"
 bbb_monitoring_all_in_one_port: 3001
 bbb_monitoring_recordings_from_disk: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -77,8 +77,14 @@
     name: apparmor
     state: reloaded
 
-- name: restart monitoring
+- name: restart monitoring container
   docker_compose:
     pull: false
     restarted: true
     project_src: "{{ bbb_monitoring_all_in_one_directory }}"
+
+- name: restart monitoring service
+  become: true
+  systemd:
+    name: bbb-exporter
+    state: restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -86,5 +86,5 @@
 - name: restart monitoring service
   become: true
   systemd:
-    name: bbb-exporter
+    name: bigbluebutton-exporter
     state: restarted

--- a/tasks/checkvars.yml
+++ b/tasks/checkvars.yml
@@ -32,19 +32,19 @@
     - name: bbb_monitoring_all_in_one_htpasswd_user
       debug:
         msg: "bbb_monitoring_all_in_one_htpasswd_user is deprecated, use bbb_monitoring_htpasswd_user instead"
-      failed_when: bbb_monitoring_all_in_one_htpasswd_user
+      failed_when: bbb_monitoring_all_in_one_htpasswd_user is defined
     - name: bbb_monitoring_htpasswd_user
       debug:
         msg: "value: {{ bbb_monitoring_htpasswd_user }}"
-      when: bbb_monitoring_external
+      when: bbb_monitoring_external | bool
     - name: bbb_monitoring_all_in_one_htpasswd
       debug:
         msg: "bbb_monitoring_all_in_one_htpasswd is deprecated, use bbb_monitoring_htpasswd instead"
-      failed_when: bbb_monitoring_all_in_one_htpasswd
+      failed_when: bbb_monitoring_all_in_one_htpasswd is defined
     - name: bbb_monitoring_htpasswd
       debug:
         msg: "value: {{ bbb_monitoring_htpasswd }}"
-      when: bbb_monitoring_external
+      when: bbb_monitoring_external | bool
 
     - name: bbb_monitoring_systemd_enable
       debug:

--- a/tasks/checkvars.yml
+++ b/tasks/checkvars.yml
@@ -27,16 +27,25 @@
       failed_when: ansible_distribution_release | lower != 'bionic'
     - name: bbb_monitoring_all_in_one_version
       debug:
-        msg: bbb_monitoring_all_in_one_version is deprecated, use bbb_monitoring_exporter_version instead
+        msg: "bbb_monitoring_all_in_one_version is deprecated, use bbb_monitoring_exporter_version instead"
       failed_when: bbb_monitoring_all_in_one_version is defined
     - name: bbb_monitoring_all_in_one_htpasswd_user
       debug:
-        msg: "value: {{ bbb_monitoring_all_in_one_htpasswd_user }}"
-      when: bbb_monitoring_all_in_one_external or bbb_monitoring_systemd_external
+        msg: "bbb_monitoring_all_in_one_htpasswd_user is deprecated, use bbb_monitoring_exporter_htpasswd_user instead"
+      failed_when: bbb_monitoring_all_in_one_htpasswd_user
+    - name: bbb_monitoring_exporter_htpasswd_user
+      debug:
+        msg: "value: {{ bbb_monitoring_exporter_htpasswd_user }}"
+      when: bbb_monitoring_exporter_external
     - name: bbb_monitoring_all_in_one_htpasswd
       debug:
-        msg: "value: {{ bbb_monitoring_all_in_one_htpasswd }}"
-      when: bbb_monitoring_all_in_one_external or bbb_monitoring_systemd_external
+        msg: "bbb_monitoring_all_in_one_htpasswd is deprecated, use bbb_monitoring_exporter_htpasswd instead"
+      failed_when: bbb_monitoring_all_in_one_htpasswd
+    - name: bbb_monitoring_exporter_htpasswd
+      debug:
+        msg: "value: {{ bbb_monitoring_exporter_htpasswd }}"
+      when: bbb_monitoring_exporter_external
+
     - name: bbb_monitoring_systemd_enable
       debug:
         msg: "Please disable monitoring for Systemd or Docker, these can not run alongside"

--- a/tasks/checkvars.yml
+++ b/tasks/checkvars.yml
@@ -31,20 +31,20 @@
       failed_when: bbb_monitoring_all_in_one_version is defined
     - name: bbb_monitoring_all_in_one_htpasswd_user
       debug:
-        msg: "bbb_monitoring_all_in_one_htpasswd_user is deprecated, use bbb_monitoring_exporter_htpasswd_user instead"
+        msg: "bbb_monitoring_all_in_one_htpasswd_user is deprecated, use bbb_monitoring_htpasswd_user instead"
       failed_when: bbb_monitoring_all_in_one_htpasswd_user
-    - name: bbb_monitoring_exporter_htpasswd_user
+    - name: bbb_monitoring_htpasswd_user
       debug:
-        msg: "value: {{ bbb_monitoring_exporter_htpasswd_user }}"
-      when: bbb_monitoring_exporter_external
+        msg: "value: {{ bbb_monitoring_htpasswd_user }}"
+      when: bbb_monitoring_external
     - name: bbb_monitoring_all_in_one_htpasswd
       debug:
-        msg: "bbb_monitoring_all_in_one_htpasswd is deprecated, use bbb_monitoring_exporter_htpasswd instead"
+        msg: "bbb_monitoring_all_in_one_htpasswd is deprecated, use bbb_monitoring_htpasswd instead"
       failed_when: bbb_monitoring_all_in_one_htpasswd
-    - name: bbb_monitoring_exporter_htpasswd
+    - name: bbb_monitoring_htpasswd
       debug:
-        msg: "value: {{ bbb_monitoring_exporter_htpasswd }}"
-      when: bbb_monitoring_exporter_external
+        msg: "value: {{ bbb_monitoring_htpasswd }}"
+      when: bbb_monitoring_external
 
     - name: bbb_monitoring_systemd_enable
       debug:

--- a/tasks/checkvars.yml
+++ b/tasks/checkvars.yml
@@ -25,6 +25,10 @@
       debug:
         msg: "distribution should be bionic and was detected as {{ ansible_distribution_release }}"
       failed_when: ansible_distribution_release | lower != 'bionic'
+    - name: bbb_monitoring_all_in_one_version
+      debug:
+        msg: bbb_monitoring_all_in_one_version is deprecated, use bbb_monitoring_exporter_version instead
+      failed_when: bbb_monitoring_all_in_one_version is defined
     - name: bbb_monitoring_all_in_one_htpasswd_user
       debug:
         msg: "value: {{ bbb_monitoring_all_in_one_htpasswd_user }}"

--- a/tasks/checkvars.yml
+++ b/tasks/checkvars.yml
@@ -33,6 +33,10 @@
       debug:
         msg: "value: {{ bbb_monitoring_all_in_one_htpasswd }}"
       when: bbb_monitoring_all_in_one_external
+    - name: bbb_monitoring_systemd_enable
+      debug:
+        msg: "Please disable monitoring for Systemd or Docker, these can not run alongside"
+      failed_when: bbb_monitoring_all_in_one_enable and bbb_monitoring_systemd_enable
   rescue:
     - name: CHECK YOUR VARIABLES!
       debug:

--- a/tasks/checkvars.yml
+++ b/tasks/checkvars.yml
@@ -36,7 +36,7 @@
     - name: bbb_monitoring_htpasswd_user
       debug:
         msg: "value: {{ bbb_monitoring_htpasswd_user }}"
-      when: bbb_monitoring_external | bool
+      when: bbb_monitoring_external
     - name: bbb_monitoring_all_in_one_htpasswd
       debug:
         msg: "bbb_monitoring_all_in_one_htpasswd is deprecated, use bbb_monitoring_htpasswd instead"
@@ -44,7 +44,7 @@
     - name: bbb_monitoring_htpasswd
       debug:
         msg: "value: {{ bbb_monitoring_htpasswd }}"
-      when: bbb_monitoring_external | bool
+      when: bbb_monitoring_external
 
     - name: bbb_monitoring_systemd_enable
       debug:

--- a/tasks/checkvars.yml
+++ b/tasks/checkvars.yml
@@ -33,10 +33,10 @@
       debug:
         msg: "bbb_monitoring_all_in_one_htpasswd_user is deprecated, use bbb_monitoring_htpasswd_user instead"
       failed_when: bbb_monitoring_all_in_one_htpasswd_user is defined
-    - name: bbb_monitoring_htpasswd_user
-      debug:
-        msg: "value: {{ bbb_monitoring_htpasswd_user }}"
-      when: bbb_monitoring_external
+#    - name: bbb_monitoring_htpasswd_user
+#      debug:
+#        msg: "value: {{ bbb_monitoring_htpasswd_user }}"
+#      when: bbb_monitoring_external
     - name: bbb_monitoring_all_in_one_htpasswd
       debug:
         msg: "bbb_monitoring_all_in_one_htpasswd is deprecated, use bbb_monitoring_htpasswd instead"

--- a/tasks/checkvars.yml
+++ b/tasks/checkvars.yml
@@ -33,10 +33,10 @@
       debug:
         msg: "bbb_monitoring_all_in_one_htpasswd_user is deprecated, use bbb_monitoring_htpasswd_user instead"
       failed_when: bbb_monitoring_all_in_one_htpasswd_user is defined
-#    - name: bbb_monitoring_htpasswd_user
-#      debug:
-#        msg: "value: {{ bbb_monitoring_htpasswd_user }}"
-#      when: bbb_monitoring_external
+    - name: bbb_monitoring_htpasswd_user
+      debug:
+        msg: "value: {{ bbb_monitoring_htpasswd_user }}"
+      when: bbb_monitoring_external
     - name: bbb_monitoring_all_in_one_htpasswd
       debug:
         msg: "bbb_monitoring_all_in_one_htpasswd is deprecated, use bbb_monitoring_htpasswd instead"
@@ -45,7 +45,6 @@
       debug:
         msg: "value: {{ bbb_monitoring_htpasswd }}"
       when: bbb_monitoring_external
-
     - name: bbb_monitoring_systemd_enable
       debug:
         msg: "Please disable monitoring for Systemd or Docker, these can not run alongside"

--- a/tasks/checkvars.yml
+++ b/tasks/checkvars.yml
@@ -28,11 +28,11 @@
     - name: bbb_monitoring_all_in_one_htpasswd_user
       debug:
         msg: "value: {{ bbb_monitoring_all_in_one_htpasswd_user }}"
-      when: bbb_monitoring_all_in_one_external
+      when: bbb_monitoring_all_in_one_external or bbb_monitoring_systemd_external
     - name: bbb_monitoring_all_in_one_htpasswd
       debug:
         msg: "value: {{ bbb_monitoring_all_in_one_htpasswd }}"
-      when: bbb_monitoring_all_in_one_external
+      when: bbb_monitoring_all_in_one_external or bbb_monitoring_systemd_external
     - name: bbb_monitoring_systemd_enable
       debug:
         msg: "Please disable monitoring for Systemd or Docker, these can not run alongside"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,11 +35,8 @@
 - import_tasks: greenlight.yml
   when: bbb_greenlight_enable | bool
 
-- import_tasks: monitoring/all_in_one.yml
-  when: bbb_monitoring_all_in_one_enable | bool
-
-- import_tasks: monitoring/systemd.yml
-  when: bbb_monitoring_systemd_enable | bool
+- import_tasks: monitoring/main.yml
+  when: bbb_monitoring_all_in_one_enable | bool or bbb_monitoring_systemd_enable | bool
 
 - import_tasks: webrtc-sfu.yml
 - import_tasks: bbb-web.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
     - runtimevars
     - always
   when:
-    - not bbb_secret is defined or not bbb_baseurl is defined or not bbbcert is defined
+    - not bbb_secret is defined or not bbbcert is defined
   ignore_errors: true
 
 - include_tasks: check-for-sessions.yml
@@ -52,7 +52,7 @@
     - runtimevars
     - always
   when:
-    - not bbb_secret is defined or not bbb_baseurl is defined or not bbbcert is defined
+    - not bbb_secret is defined or not bbbcert is defined
 
 - import_tasks: letsencrypt.yml
   when: bbb_letsencrypt_enable | bool and not bbbcert.stat.exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,10 +36,10 @@
   when: bbb_greenlight_enable | bool
 
 - import_tasks: monitoring/all_in_one.yml
-  when: bbb_monitoring_all_in_one_enable | bool and not (bbb_monitoring_systemd_enable | bool)
+  when: bbb_monitoring_all_in_one_enable
 
 - import_tasks: monitoring/systemd.yml
-  when: bbb_monitoring_systemd_enable | bool and not (bbb_monitoring_all_in_one_enable | bool)
+  when: bbb_monitoring_systemd_enable
 
 - import_tasks: webrtc-sfu.yml
 - import_tasks: bbb-web.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,7 +36,7 @@
   when: bbb_greenlight_enable | bool
 
 - import_tasks: monitoring/all_in_one.yml
-  when: bbb_monitoring_all_in_one_enable
+  when: bbb_monitoring_all_in_one_enable | bool
 
 - import_tasks: monitoring/systemd.yml
   when: bbb_monitoring_systemd_enable | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,7 +36,10 @@
   when: bbb_greenlight_enable | bool
 
 - import_tasks: monitoring/all_in_one.yml
-  when: bbb_monitoring_all_in_one_enable | bool
+  when: bbb_monitoring_all_in_one_enable | bool and not (bbb_monitoring_systemd_enable | bool)
+
+- import_tasks: monitoring/systemd.yml
+  when: bbb_monitoring_systemd_enable | bool and not (bbb_monitoring_all_in_one_enable | bool)
 
 - import_tasks: webrtc-sfu.yml
 - import_tasks: bbb-web.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,7 +39,7 @@
   when: bbb_monitoring_all_in_one_enable
 
 - import_tasks: monitoring/systemd.yml
-  when: bbb_monitoring_systemd_enable
+  when: bbb_monitoring_systemd_enable | bool
 
 - import_tasks: webrtc-sfu.yml
 - import_tasks: bbb-web.yml

--- a/tasks/monitoring/all_in_one.yml
+++ b/tasks/monitoring/all_in_one.yml
@@ -14,7 +14,7 @@
     - bbb_exporter_secrets.env
     - docker-compose.yaml
     - prometheus.yaml
-  notify: restart monitoring
+  notify: restart monitoring container
 
 - name: copy monitoring nginx configuration file
   template:

--- a/tasks/monitoring/all_in_one.yml
+++ b/tasks/monitoring/all_in_one.yml
@@ -16,25 +16,6 @@
     - prometheus.yaml
   notify: restart monitoring container
 
-- name: copy monitoring nginx configuration file
-  template:
-    src: "monitoring/monitoring.nginx.j2"
-    dest: "/etc/bigbluebutton/nginx/monitoring.nginx"
-    mode: '0644'
-  notify: reload nginx
-
-- name: Generate htpasswd file for external access if enabled
-  htpasswd:
-    path: "/etc/bigbluebutton/nginx/.htpasswd"
-    name: "{{ bbb_monitoring_all_in_one_htpasswd_user }}"
-    password: "{{ bbb_monitoring_all_in_one_htpasswd }}"
-    owner: root
-    group: root
-    mode: 0644
-  no_log: true
-  notify: reload nginx
-  when: bbb_monitoring_all_in_one_external
-
 - name: start monitoring
   docker_compose:
     pull: true

--- a/tasks/monitoring/main.yml
+++ b/tasks/monitoring/main.yml
@@ -1,0 +1,27 @@
+---
+- import_tasks: all_in_one.yml
+  when: bbb_monitoring_all_in_one_enable | bool
+
+- import_tasks: systemd.yml
+  when: bbb_monitoring_systemd_enable | bool
+
+- name: Copy monitoring nginx configuration file
+  template:
+    src: "monitoring/monitoring.nginx.j2"
+    dest: "/etc/bigbluebutton/nginx/monitoring.nginx"
+    mode: '0644'
+  notify:
+    - reload nginx
+
+- name: Generate htpasswd file for external access if enabled
+  htpasswd:
+    path: "/etc/bigbluebutton/nginx/.htpasswd"
+    name: "{{ bbb_monitoring_all_in_one_htpasswd_user }}"
+    password: "{{ bbb_monitoring_all_in_one_htpasswd }}"
+    owner: root
+    group: root
+    mode: 0644
+  no_log: true
+  when: bbb_monitoring_all_in_one_external | bool or bbb_monitoring_systemd_external | bool
+  notify:
+    - reload nginx

--- a/tasks/monitoring/main.yml
+++ b/tasks/monitoring/main.yml
@@ -16,12 +16,12 @@
 - name: Generate htpasswd file for external access if enabled
   htpasswd:
     path: "/etc/bigbluebutton/nginx/.htpasswd"
-    name: "{{ bbb_monitoring_exporter_htpasswd_user }}"
-    password: "{{ bbb_monitoring_exporter_htpasswd }}"
+    name: "{{ bbb_monitoring_htpasswd_user }}"
+    password: "{{ bbb_monitoring_htpasswd }}"
     owner: root
     group: root
     mode: 0644
   no_log: true
-  when: bbb_monitoring_exporter_external | bool
+  when: bbb_monitoring_external | bool
   notify:
     - reload nginx

--- a/tasks/monitoring/main.yml
+++ b/tasks/monitoring/main.yml
@@ -16,12 +16,12 @@
 - name: Generate htpasswd file for external access if enabled
   htpasswd:
     path: "/etc/bigbluebutton/nginx/.htpasswd"
-    name: "{{ bbb_monitoring_all_in_one_htpasswd_user }}"
-    password: "{{ bbb_monitoring_all_in_one_htpasswd }}"
+    name: "{{ bbb_monitoring_exporter_htpasswd_user }}"
+    password: "{{ bbb_monitoring_exporter_htpasswd }}"
     owner: root
     group: root
     mode: 0644
   no_log: true
-  when: bbb_monitoring_all_in_one_external | bool or bbb_monitoring_systemd_external | bool
+  when: bbb_monitoring_exporter_external | bool
   notify:
     - reload nginx

--- a/tasks/monitoring/systemd.yml
+++ b/tasks/monitoring/systemd.yml
@@ -6,6 +6,14 @@
     home: "{{ bbb_monitoring_systemd_directory }}"
     create_home: no
 
+- name: Create systemd directory
+  file:
+    path: "{{ bbb_monitoring_systemd_directory }}"
+    state: directory
+    user: bbb-exporter
+    group: bbb-exporter
+    mode: '0755'
+
 - name: Deploy git repository to host
   git:
     repo: https://github.com/greenstatic/bigbluebutton-exporter.git

--- a/tasks/monitoring/systemd.yml
+++ b/tasks/monitoring/systemd.yml
@@ -39,7 +39,7 @@
     state: directory
     mode: '0755'
 
-- name: Copy secret file info configuration directory
+- name: Template exporter configuration
   template:
     src: "monitoring/bbb_exporter_secrets.env.j2"
     dest: "/etc/bigbluebutton-exporter/settings.env"

--- a/tasks/monitoring/systemd.yml
+++ b/tasks/monitoring/systemd.yml
@@ -1,0 +1,58 @@
+---
+- name: Create monitoring user
+    user:
+      name: bbb-exporter
+      shell: /usr/sbin/nologin
+      home: "{{ bbb_monitoring_systemd_directory }}"
+
+- name: Deploy git repository to host
+  git:
+    repo: https://github.com/greenstatic/bigbluebutton-exporter.git
+    branch: master
+    dest: "{{ bbb_monitoring_systemd_directory }}"
+    verion: "{{ bbb_monitoring_systemd_version }}"
+  become_user: bbb-exporter
+
+- name: Install specified python requirements and custom Index URL
+  pip:
+    requirements: "{{ bbb_monitoring_systemd_directory }}/requirements.txt"
+
+- name: Copy systemd service into place
+  copy:
+    src: "{{ bbb_monitoring_systemd_directory }}/extras/systemd/bigbluebutton-exporter.service"
+    dest: /lib/systemd/system/
+    owner: root
+    group: root
+    mode: '0644'
+    remote_src: yes
+
+- name: Copy secret file info configuration directory
+  template:
+    src: "monitoring/bbb_exporter_secrets.env.j2"
+    dest: "/etc/bigbluebutton-exporter/bbb_exporter_secrets.env"
+    mode: '0644'
+  notify: restart monitoring service
+
+- name: Copy monitoring nginx configuration file
+  template:
+    src: "monitoring/monitoring.nginx.j2"
+    dest: "/etc/bigbluebutton/nginx/monitoring.nginx"
+    mode: '0644'
+  notify: reload nginx
+
+- name: Generate htpasswd file for external access if enabled
+  htpasswd:
+    path: "/etc/bigbluebutton/nginx/.htpasswd"
+    name: "{{ bbb_monitoring_all_in_one_htpasswd_user }}"
+    password: "{{ bbb_monitoring_all_in_one_htpasswd }}"
+    owner: root
+    group: root
+    mode: 0644
+  notify: reload nginx
+  when: bbb_monitoring_systemd_external
+
+- name: start monitoring
+  systemd:
+    name: bigbluebutton-exporter
+    state: started
+    enabled: yes

--- a/tasks/monitoring/systemd.yml
+++ b/tasks/monitoring/systemd.yml
@@ -18,6 +18,7 @@
     state: directory
     owner: bbb-exporter
     group: bbb-exporter
+    more: '0755'
 
 - name: Install specified python requirements and custom Index URL
   pip:
@@ -36,7 +37,7 @@
   file:
     path: "/etc/bigbluebutton-exporter"
     state: directory
-    mode: '755'
+    mode: '0755'
 
 - name: Copy secret file info configuration directory
   template:

--- a/tasks/monitoring/systemd.yml
+++ b/tasks/monitoring/systemd.yml
@@ -5,6 +5,7 @@
     shell: /usr/sbin/nologin
     home: "{{ bbb_monitoring_systemd_directory }}"
     create_home: false
+    system: true
 
 - name: Deploy git repository to host
   git:

--- a/tasks/monitoring/systemd.yml
+++ b/tasks/monitoring/systemd.yml
@@ -4,20 +4,20 @@
     name: bbb-exporter
     shell: /usr/sbin/nologin
     home: "{{ bbb_monitoring_systemd_directory }}"
-    create_home: yes
-
-- name: Delete Ansible tmp file
-  file:
-    path: "{{ bbb_monitoring_systemd_directory }}/.ansible"
-    state: absent
+    create_home: no
 
 - name: Deploy git repository to host
   git:
     repo: https://github.com/greenstatic/bigbluebutton-exporter.git
     dest: "{{ bbb_monitoring_systemd_directory }}"
     version: "{{ bbb_monitoring_systemd_version }}"
-  become: yes
-  become_user: bbb-exporter
+
+- name: Change ownership directory
+  file:
+    path: "{{ bbb_monitoring_systemd_directory }}"
+    state: directory
+    owner: bbb-exporter
+    group: bbb-exporter
 
 - name: Install specified python requirements and custom Index URL
   pip:

--- a/tasks/monitoring/systemd.yml
+++ b/tasks/monitoring/systemd.yml
@@ -40,7 +40,7 @@
 - name: Copy secret file info configuration directory
   template:
     src: "monitoring/bbb_exporter_secrets.env.j2"
-    dest: "/etc/bigbluebutton-exporter/bbb_exporter_secrets.env"
+    dest: "/etc/bigbluebutton-exporter/settings.env"
     mode: '0644'
   notify: restart monitoring service
 

--- a/tasks/monitoring/systemd.yml
+++ b/tasks/monitoring/systemd.yml
@@ -18,7 +18,7 @@
     state: directory
     owner: bbb-exporter
     group: bbb-exporter
-    more: '0755'
+    mode: '0755'
 
 - name: Install specified python requirements and custom Index URL
   pip:

--- a/tasks/monitoring/systemd.yml
+++ b/tasks/monitoring/systemd.yml
@@ -32,6 +32,11 @@
     mode: '0644'
     remote_src: yes
 
+- name: Create /etc/bigbluebutton-exporter directory
+  file:
+    path: "/etc/bigbluebutton-exporter"
+    state: directory
+
 - name: Copy secret file info configuration directory
   template:
     src: "monitoring/bbb_exporter_secrets.env.j2"

--- a/tasks/monitoring/systemd.yml
+++ b/tasks/monitoring/systemd.yml
@@ -23,6 +23,13 @@
     group: bbb-exporter
     mode: '0755'
 
+- name: Ensure pip is installed
+  apt:
+    name:
+      - python3-pip
+      - python3-setuptools
+    state: "{{ bbb_state }}"
+
 - name: Install specified python requirements and custom Index URL
   pip:
     requirements: "{{ bbb_monitoring_systemd_directory }}/requirements.txt"

--- a/tasks/monitoring/systemd.yml
+++ b/tasks/monitoring/systemd.yml
@@ -12,6 +12,8 @@
     repo: https://github.com/greenstatic/bigbluebutton-exporter.git
     dest: "{{ bbb_monitoring_systemd_directory }}"
     version: "{{ bbb_monitoring_systemd_version }}"
+  notify:
+    - restart monitoring service
 
 - name: Change ownership directory
   file:
@@ -24,6 +26,8 @@
 - name: Install specified python requirements and custom Index URL
   pip:
     requirements: "{{ bbb_monitoring_systemd_directory }}/requirements.txt"
+  notify:
+    - restart monitoring service
 
 - name: Copy systemd service into place
   copy:
@@ -33,6 +37,9 @@
     group: root
     mode: '0644'
     remote_src: true
+  notify:
+    - reload systemd
+    - restart monitoring service
 
 - name: Create /etc/bigbluebutton-exporter directory
   file:
@@ -45,14 +52,16 @@
     src: "monitoring/bbb_exporter_secrets.env.j2"
     dest: "/etc/bigbluebutton-exporter/settings.env"
     mode: '0644'
-  notify: restart monitoring service
+  notify:
+    - restart monitoring service
 
 - name: Copy monitoring nginx configuration file
   template:
     src: "monitoring/monitoring.nginx.j2"
     dest: "/etc/bigbluebutton/nginx/monitoring.nginx"
     mode: '0644'
-  notify: reload nginx
+  notify:
+    - reload nginx
 
 - name: Generate htpasswd file for external access if enabled
   htpasswd:
@@ -62,8 +71,9 @@
     owner: root
     group: root
     mode: 0644
-  notify: reload nginx
   when: bbb_monitoring_systemd_external
+  notify:
+    - reload nginx
 
 - name: start monitoring
   systemd:

--- a/tasks/monitoring/systemd.yml
+++ b/tasks/monitoring/systemd.yml
@@ -11,7 +11,7 @@
   git:
     repo: https://github.com/greenstatic/bigbluebutton-exporter.git
     dest: "{{ bbb_monitoring_systemd_directory }}"
-    version: "{{ bbb_monitoring_systemd_version }}"
+    version: "{{ bbb_monitoring_exporter_version }}"
   notify:
     - restart monitoring service
 

--- a/tasks/monitoring/systemd.yml
+++ b/tasks/monitoring/systemd.yml
@@ -1,9 +1,9 @@
 ---
 - name: Create monitoring user
-    user:
-      name: bbb-exporter
-      shell: /usr/sbin/nologin
-      home: "{{ bbb_monitoring_systemd_directory }}"
+  user:
+    name: bbb-exporter
+    shell: /usr/sbin/nologin
+    home: "{{ bbb_monitoring_systemd_directory }}"
 
 - name: Deploy git repository to host
   git:

--- a/tasks/monitoring/systemd.yml
+++ b/tasks/monitoring/systemd.yml
@@ -10,7 +10,7 @@
   file:
     path: "{{ bbb_monitoring_systemd_directory }}"
     state: directory
-    user: bbb-exporter
+    owner: bbb-exporter
     group: bbb-exporter
     mode: '0755'
 

--- a/tasks/monitoring/systemd.yml
+++ b/tasks/monitoring/systemd.yml
@@ -10,7 +10,8 @@
     repo: https://github.com/greenstatic/bigbluebutton-exporter.git
     branch: master
     dest: "{{ bbb_monitoring_systemd_directory }}"
-    verion: "{{ bbb_monitoring_systemd_version }}"
+    version: "{{ bbb_monitoring_systemd_version }}"
+  become: yes
   become_user: bbb-exporter
 
 - name: Install specified python requirements and custom Index URL

--- a/tasks/monitoring/systemd.yml
+++ b/tasks/monitoring/systemd.yml
@@ -4,6 +4,7 @@
     name: bbb-exporter
     shell: /usr/sbin/nologin
     home: "{{ bbb_monitoring_systemd_directory }}"
+    create_home: no
 
 - name: Deploy git repository to host
   git:

--- a/tasks/monitoring/systemd.yml
+++ b/tasks/monitoring/systemd.yml
@@ -4,7 +4,7 @@
     name: bbb-exporter
     shell: /usr/sbin/nologin
     home: "{{ bbb_monitoring_systemd_directory }}"
-    create_home: no
+    create_home: false
 
 - name: Deploy git repository to host
   git:
@@ -30,12 +30,13 @@
     owner: root
     group: root
     mode: '0644'
-    remote_src: yes
+    remote_src: true
 
 - name: Create /etc/bigbluebutton-exporter directory
   file:
     path: "/etc/bigbluebutton-exporter"
     state: directory
+    mode: '755'
 
 - name: Copy secret file info configuration directory
   template:
@@ -66,4 +67,4 @@
   systemd:
     name: bigbluebutton-exporter
     state: started
-    enabled: yes
+    enabled: true

--- a/tasks/monitoring/systemd.yml
+++ b/tasks/monitoring/systemd.yml
@@ -8,7 +8,6 @@
 - name: Deploy git repository to host
   git:
     repo: https://github.com/greenstatic/bigbluebutton-exporter.git
-    branch: master
     dest: "{{ bbb_monitoring_systemd_directory }}"
     version: "{{ bbb_monitoring_systemd_version }}"
   become: yes

--- a/tasks/monitoring/systemd.yml
+++ b/tasks/monitoring/systemd.yml
@@ -62,26 +62,6 @@
   notify:
     - restart monitoring service
 
-- name: Copy monitoring nginx configuration file
-  template:
-    src: "monitoring/monitoring.nginx.j2"
-    dest: "/etc/bigbluebutton/nginx/monitoring.nginx"
-    mode: '0644'
-  notify:
-    - reload nginx
-
-- name: Generate htpasswd file for external access if enabled
-  htpasswd:
-    path: "/etc/bigbluebutton/nginx/.htpasswd"
-    name: "{{ bbb_monitoring_all_in_one_htpasswd_user }}"
-    password: "{{ bbb_monitoring_all_in_one_htpasswd }}"
-    owner: root
-    group: root
-    mode: 0644
-  when: bbb_monitoring_systemd_external
-  notify:
-    - reload nginx
-
 - name: start monitoring
   systemd:
     name: bigbluebutton-exporter

--- a/tasks/monitoring/systemd.yml
+++ b/tasks/monitoring/systemd.yml
@@ -4,15 +4,12 @@
     name: bbb-exporter
     shell: /usr/sbin/nologin
     home: "{{ bbb_monitoring_systemd_directory }}"
-    create_home: no
+    create_home: yes
 
-- name: Create systemd directory
+- name: Delete Ansible tmp file
   file:
-    path: "{{ bbb_monitoring_systemd_directory }}"
-    state: directory
-    owner: bbb-exporter
-    group: bbb-exporter
-    mode: '0755'
+    path: "{{ bbb_monitoring_systemd_directory }}/.ansible"
+    state: absent
 
 - name: Deploy git repository to host
   git:

--- a/tasks/runtimevars.yml
+++ b/tasks/runtimevars.yml
@@ -9,16 +9,10 @@
   command: bbb-conf --secret
   changed_when: false
   register: result
-  when: not bbb_secret is defined or not bbb_baseurl is defined
+  when: not bbb_secret is defined
 
 - name: parse bbb secret
   set_fact:
     bbb_secret: "{{ result.stdout | regex_search('Secret: ([a-zA-Z0-9]*)', multiline=True) |  regex_replace('Secret: ') }}"
     cacheable: true
   when: not bbb_secret is defined
-
-- name: parse bbb baseurl
-  set_fact:
-    bbb_baseurl: "{{ result.stdout | regex_search('URL:\\s*(https?:\\/\\/.*)', multiline=True) |  regex_replace('URL: ') }}"
-    cacheable: true
-  when: not bbb_baseurl is defined

--- a/templates/monitoring/bbb_exporter_secrets.env.j2
+++ b/templates/monitoring/bbb_exporter_secrets.env.j2
@@ -1,2 +1,8 @@
-API_BASE_URL={{ bbb_baseurl }}api/
+API_BASE_URL=https://{{ bbb_hostname }}/bigbluebutton/api/
 API_SECRET={{ bbb_secret }}
+{% if bbb_monitoring_systemd_bind_ip | bool %}
+BIND_IP={{ bbb_monitoring_systemd_bind_ip }}
+{% endif %}
+{% if bbb_monitoring_systemd_port | bool %}
+PORT={{ bbb_monitoring_systemd_port }}
+{% endif %}

--- a/templates/monitoring/bbb_exporter_secrets.env.j2
+++ b/templates/monitoring/bbb_exporter_secrets.env.j2
@@ -1,8 +1,8 @@
 API_BASE_URL=https://{{ bbb_hostname }}/bigbluebutton/api/
 API_SECRET={{ bbb_secret }}
-{% if bbb_monitoring_systemd_bind_ip | bool %}
+{% if bbb_monitoring_systemd_bind_ip is defined %}
 BIND_IP={{ bbb_monitoring_systemd_bind_ip }}
 {% endif %}
-{% if bbb_monitoring_systemd_port | bool %}
+{% if bbb_monitoring_systemd_port is defined %}
 PORT={{ bbb_monitoring_systemd_port }}
 {% endif %}

--- a/templates/monitoring/docker-compose.yaml.j2
+++ b/templates/monitoring/docker-compose.yaml.j2
@@ -2,7 +2,7 @@ version: '3.2'
 services:
   bbb-exporter:
     container_name: bbb-exporter
-    image: greenstatic/bigbluebutton-exporter:{{ bbb_monitoring_all_in_one_version }}
+    image: greenstatic/bigbluebutton-exporter:{{ bbb_monitoring_exporter_version }}
     network_mode: host
     volumes:
       # Can be removed if `RECORDINGS_METRICS_READ_FROM_DISK` is set to false (or omitted).

--- a/templates/monitoring/docker-compose.yaml.j2
+++ b/templates/monitoring/docker-compose.yaml.j2
@@ -10,7 +10,7 @@ services:
       - "/var/bigbluebutton:/var/bigbluebutton:ro"
     environment:
       BIND_IP: "127.0.0.1"
-      RECORDINGS_METRICS_READ_FROM_DISK: "{{ bbb_monitoring_all_in_one_recordings_from_disk | ternary("true", "false") }}"
+      RECORDINGS_METRICS_READ_FROM_DISK: "{{ bbb_monitoring_recordings_from_disk | ternary("true", "false") }}"
     env_file:
       - bbb_exporter_secrets.env
     restart: unless-stopped

--- a/templates/monitoring/docker-compose.yaml.j2
+++ b/templates/monitoring/docker-compose.yaml.j2
@@ -10,7 +10,7 @@ services:
       - "/var/bigbluebutton:/var/bigbluebutton:ro"
     environment:
       BIND_IP: "127.0.0.1"
-      RECORDINGS_METRICS_READ_FROM_DISK: "{{ bbb_monitoring_recordings_from_disk | ternary("true", "false") }}"
+      RECORDINGS_METRICS_READ_FROM_DISK: "{{ bbb_monitoring_all_in_one_recordings_from_disk | ternary("true", "false") }}"
     env_file:
       - bbb_exporter_secrets.env
     restart: unless-stopped

--- a/templates/monitoring/monitoring.nginx.j2
+++ b/templates/monitoring/monitoring.nginx.j2
@@ -1,14 +1,4 @@
-{% if not bbb_monitoring_all_in_one_external and not bbb_monitoring_systemd_enable %}
-location /monitoring/ {
-  proxy_pass http://127.0.0.1:{{ bbb_monitoring_all_in_one_port }}/;
-  include proxy_params;
-}
-{% elif not bbb_monitoring_systemd_external and not bbb_monitoring_all_in_one_enable %}
-location /monitoring/ {
-  proxy_pass http://127.0.0.1:{{ bbb_monitoring_systemd_port }}/;
-  include proxy_params;
-}
-{% else %}
+{% if bbb_monitoring_all_in_one_external or bbb_monitoring_systemd_external %}
 location /mon/node/ {
   proxy_pass http://127.0.0.1:9100/metrics;
   auth_basic "BigBlueButton Exporter";
@@ -20,6 +10,13 @@ location /mon/bbb/ {
   proxy_pass http://127.0.0.1:9688/;
   auth_basic "BigBlueButton Exporter";
   auth_basic_user_file /etc/bigbluebutton/nginx/.htpasswd;
+  include proxy_params;
+}
+{% else %}
+{% set bbb_monitoring_exporter_port = (bbb_monitoring_all_in_one_enabled | bool
+    | ternary(bbb_monitoring_all_in_one_port, bbb_monitoring_systemd_port, 9688) %}
+location /monitoring/ {
+  proxy_pass http://127.0.0.1:{{ bbb_monitoring_exporter_port }}/;
   include proxy_params;
 }
 {% endif %}

--- a/templates/monitoring/monitoring.nginx.j2
+++ b/templates/monitoring/monitoring.nginx.j2
@@ -14,7 +14,7 @@ location /mon/bbb/ {
 }
 {% else %}
 {% set bbb_monitoring_exporter_port = (bbb_monitoring_all_in_one_enabled | bool
-    | ternary(bbb_monitoring_all_in_one_port, bbb_monitoring_systemd_port, 9688) %}
+    | ternary(bbb_monitoring_all_in_one_port, bbb_monitoring_systemd_port, 9688)) %}
 location /monitoring/ {
   proxy_pass http://127.0.0.1:{{ bbb_monitoring_exporter_port }}/;
   include proxy_params;

--- a/templates/monitoring/monitoring.nginx.j2
+++ b/templates/monitoring/monitoring.nginx.j2
@@ -1,6 +1,11 @@
-{% if not bbb_monitoring_all_in_one_external %}
+{% if not bbb_monitoring_all_in_one_external and not bbb_monitoring_systemd_enable %}
 location /monitoring/ {
   proxy_pass http://127.0.0.1:{{ bbb_monitoring_all_in_one_port }}/;
+  include proxy_params;
+}
+{% elif not bbb_monitoring_systemd_external and not bbb_monitoring_all_in_one_enable %}
+location /monitoring/ {
+  proxy_pass http://127.0.0.1:{{ bbb_monitoring_systemd_port }}/;
   include proxy_params;
 }
 {% else %}

--- a/templates/monitoring/monitoring.nginx.j2
+++ b/templates/monitoring/monitoring.nginx.j2
@@ -1,4 +1,4 @@
-{% if bbb_monitoring_exporter_external %}
+{% if bbb_monitoring_external %}
 location /mon/node/ {
   proxy_pass http://127.0.0.1:9100/metrics;
   auth_basic "BigBlueButton Exporter";

--- a/templates/monitoring/monitoring.nginx.j2
+++ b/templates/monitoring/monitoring.nginx.j2
@@ -1,4 +1,4 @@
-{% if bbb_monitoring_all_in_one_external or bbb_monitoring_systemd_external %}
+{% if bbb_monitoring_exporter_external %}
 location /mon/node/ {
   proxy_pass http://127.0.0.1:9100/metrics;
   auth_basic "BigBlueButton Exporter";

--- a/templates/monitoring/monitoring.nginx.j2
+++ b/templates/monitoring/monitoring.nginx.j2
@@ -13,8 +13,7 @@ location /mon/bbb/ {
   include proxy_params;
 }
 {% else %}
-{% set bbb_monitoring_exporter_port = (bbb_monitoring_all_in_one_enabled | bool
-    | ternary(bbb_monitoring_all_in_one_port, bbb_monitoring_systemd_port, 9688)) %}
+{% set bbb_monitoring_exporter_port = (bbb_monitoring_all_in_one_enabled true | ternary(bbb_monitoring_all_in_one_port, bbb_monitoring_systemd_port, 9688)) %}
 location /monitoring/ {
   proxy_pass http://127.0.0.1:{{ bbb_monitoring_exporter_port }}/;
   include proxy_params;

--- a/templates/monitoring/monitoring.nginx.j2
+++ b/templates/monitoring/monitoring.nginx.j2
@@ -13,7 +13,7 @@ location /mon/bbb/ {
   include proxy_params;
 }
 {% else %}
-{% set bbb_monitoring_exporter_port = bbb_monitoring_all_in_one_enabled | ternary(bbb_monitoring_all_in_one_port, bbb_monitoring_systemd_port, 9688) %}
+{% set bbb_monitoring_exporter_port = (bbb_monitoring_all_in_one_enable | bool | ternary(bbb_monitoring_all_in_one_port, bbb_monitoring_systemd_port, 9688)) %}
 location /monitoring/ {
   proxy_pass http://127.0.0.1:{{ bbb_monitoring_exporter_port }}/;
   include proxy_params;

--- a/templates/monitoring/monitoring.nginx.j2
+++ b/templates/monitoring/monitoring.nginx.j2
@@ -13,7 +13,7 @@ location /mon/bbb/ {
   include proxy_params;
 }
 {% else %}
-{% set bbb_monitoring_exporter_port = (bbb_monitoring_all_in_one_enabled true | ternary(bbb_monitoring_all_in_one_port, bbb_monitoring_systemd_port, 9688)) %}
+{% set bbb_monitoring_exporter_port = bbb_monitoring_all_in_one_enabled | ternary(bbb_monitoring_all_in_one_port, bbb_monitoring_systemd_port, 9688) %}
 location /monitoring/ {
   proxy_pass http://127.0.0.1:{{ bbb_monitoring_exporter_port }}/;
   include proxy_params;


### PR DESCRIPTION
# Other changes
* Added lock against installing bigbluebutton-exporter as Docker and as Systemd service at the same time
* Changed reload monitoring handler name
# Questions
* [x] Can variable `bbb_monitoring_recordings_from_disk` rename in `bbb_monitoring_all_in_one_recordings_from_disk`?
* [x] Should variables like `bbb_monitoring_all_in_one_htpasswd` used for both environments or should they be separate?