### PR TITLE
fix yaml indentation in templates

### DIFF
--- a/tasks/bbb-html5.yml
+++ b/tasks/bbb-html5.yml
@@ -3,7 +3,7 @@
 - name: write custom meteor config
   become: true
   copy:
-    content: '{{ bbb_meteor | to_nice_yaml }}'
+    content: '{{ bbb_meteor | to_nice_yaml(indent=2) }}'
     dest: /etc/bigbluebutton/bbb-html5.yml
     mode: '0644'
   notify:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -93,7 +93,7 @@
 
 - name: write back new meteor config
   copy:
-    content: '{{ meteor  | to_nice_yaml }}'
+    content: '{{ meteor | to_nice_yaml(indent=2) }}'
     dest: /usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml
     mode: '0644'
   notify:

--- a/tasks/webrtc-sfu.yml
+++ b/tasks/webrtc-sfu.yml
@@ -26,7 +26,7 @@
 - name: write custom webrtc-sfu config
   become: true
   copy:
-    content: '{{ bbb_webrtc_sfu_multikurento | to_nice_yaml }}'
+    content: '{{ bbb_webrtc_sfu_multikurento | to_nice_yaml(indent=2) }}'
     dest: /etc/bigbluebutton/bbb-webrtc-sfu/production.yml
     mode: '0644'
   notify:


### PR DESCRIPTION
Without "indent=2", to_nice_yaml() adds to much spaces, e.g. in /etc/bigbluebutton/bbb-webrtc-sfu/production.yml:
```
balancing-strategy: MEDIA_TYPE
freeswitch:
    esl_password: <password>
    ip: <ip>
    sip_ip: <ip>
kurento:
-   ip: <ip>
    ipClassMappings:
        local: ''
```