### PR TITLE
greenlight: allow for provider-type in user:create

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,8 @@ bbb_greenlight_enable: true
 bbb_greenlight_users: []
 #  - { name: '', email: '', password: '', type: 'user' }
 #  - { name: '', email: '', password: '', type: 'admin' }
+# You can also give the provider name as last argument
+#  - { name: '', email: '', password: '', type: 'admin', provider: 'oauth2' }
 
 bbb_webhooks_enable: false
 bbb_allow_mail_notifications: true

--- a/tasks/greenlight.yml
+++ b/tasks/greenlight.yml
@@ -50,7 +50,7 @@
     - name: Create greenlight users
       community.docker.docker_container_exec:
         container: greenlight-v2
-      command: "docker exec greenlight-v2 bundle exec rake user:create[\"{{ item.name }}\",\"{{ item.email }}\",\"{{ item.password }}\",\"{{ item.type }}{{ ',' + item.provider if 'provider' in item.keys() else '' }}\"]"
+      command: "docker exec greenlight-v2 bundle exec rake user:create[\"{{ item.name }}\",\"{{ item.email }}\",\"{{ item.password }}\",\"{{ item.type }}\"{{ ',\"' + item.provider + '\"' if 'provider' in item.keys() else '' }}]"
       loop: "{{ bbb_greenlight_users | flatten(levels=1) }}"
       register: usercreate
       failed_when: "'Invalid Arguments' in usercreate.stdout"

--- a/tasks/greenlight.yml
+++ b/tasks/greenlight.yml
@@ -50,7 +50,7 @@
     - name: Create greenlight users
       community.docker.docker_container_exec:
         container: greenlight-v2
-        command: "bundle exec rake user:create[\"{{ item.name }}\",\"{{ item.email }}\",\"{{ item.password }}\",\"{{ item.type }}\"]"
+      command: "docker exec greenlight-v2 bundle exec rake user:create[\"{{ item.name }}\",\"{{ item.email }}\",\"{{ item.password }}\",\"{{ item.type }}{{ ',' + item.provider if 'provider' in item.keys() else '' }}\"]"
       loop: "{{ bbb_greenlight_users | flatten(levels=1) }}"
       register: usercreate
       failed_when: "'Invalid Arguments' in usercreate.stdout"


### PR DESCRIPTION
Fixes #135 - although I'm not sure if it's actually useful, because it still waits for changes in Greenlight...

Perhaps it helps with other providers than LDAP? Or other use cases?