### PR TITLE
mongo4-ramdisk.conf: follow upstream changes from v2.3.2

### DIFF
--- a/templates/mongo4-ramdisk.conf
+++ b/templates/mongo4-ramdisk.conf
@@ -9,7 +9,7 @@ storage:
 #   enabled: false
   wiredTiger:
     engineConfig:
-         cacheSizeGB: 0
+         cacheSizeGB: 1
          journalCompressor: none
          directoryForIndexes: true
     collectionConfig:
@@ -26,6 +26,9 @@ net:
   port: 27017
   bindIp: 127.0.1.1
 
-
 replication:
   replSetName: rs0
+
+setParameter:
+  diagnosticDataCollectionEnabled: false
+


### PR DESCRIPTION
Hi there,
I noticed some changes in this file which were made in BBB 2.3.2.
Whats about this? (I haven't included this change yet).
```
-  journal:
-   enabled: true
+#  journal:
+#   enabled: false
```

Is this for a reason?