### PR TITLE
add backend for html5-client according to https://docs.bigbluebutton.…

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Also check [Before you install](https://docs.bigbluebutton.org/2.3/install.html#
 | `bbb_allow_mail_notifications`  | Set this to true if you want GreenLight to send verification emails upon the creation of a new account | `true` |
 | `bbb_disable_recordings` | Disable options in gui to have recordings | `no` | [Recordings are running constantly in background](https://github.com/bigbluebutton/bigbluebutton/issues/9202) which is relevant as privacy relevant user data is stored |
 | `bbb_api_demos_enable` | enable installation of the api demos | `no` | |
+| `bbb_client_log_enable` | enable installation of the nginx-full and config for client logging according to [BBB Customization Docs](https://docs.bigbluebutton.org/2.2/customize.html#collect-feedback-from-the-users). See "METEOR" Section below for needed `bbb_meteor` values. | `false` | |
 | `bbb_mute_on_start:` | start with muted mic on join | `no` | |
 | `bbb_app_log_level:` | set bigbluebutton log level | `DEBUG` | |
 | `bbb_meteor:` | overwrite settings in meteor | `{}` | |
@@ -310,6 +311,19 @@ bbb_meteor:
         mobilePageSizes:
           moderator: 8
           viewer: 8
+```
+
+To enable client logging and/or userfeedback, you need to set `bbb_client_log_enable` to `true` add the following keys here:
+
+```yaml
+bbb_meteor:
+  public:
+    app:
+      askForFeedbackOnLogout: true
+    clientLog:
+      external:
+        enabled: true
+        url: "https://{{ bbb_hostname }}/html5log"
 ```
 
 ### LXD/LXC compatibility

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ bbb_meteor:
           moderator: 8
           viewer: 8
 ```
-
+#### User Feedback logging
 To enable client logging and/or userfeedback, you need to set `bbb_client_log_enable` to `true` add the following keys here:
 
 ```yaml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ bbb_letsencrypt_api: https://acme-v02.api.letsencrypt.org/directory
 bbb_nginx_privacy: true
 bbb_nginx_listen_https: true
 bbb_nginx_root: /var/www/bigbluebutton-default
+bbb_client_log_enable: false
 
 bbb_coturn_enable: true
 bbb_coturn_port: 3478

--- a/files/html5-client-log.conf
+++ b/files/html5-client-log.conf
@@ -1,0 +1,2 @@
+log_format postdata '\$remote_addr [\$time_iso8601] \$request_body';
+

--- a/files/html5-client-log.nginx
+++ b/files/html5-client-log.nginx
@@ -1,0 +1,5 @@
+location /html5log {
+        access_log /var/log/nginx/html5-client.log postdata;
+        echo_read_request_body;
+}
+

--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -13,6 +13,21 @@
     dest: /etc/alternatives/java
     state: link
 
+- name: install nginx-full for client-logging
+  become: true
+  apt:
+    name: nginx-full
+    state: "{{ bbb_state }}"
+  when: bbb_client_log_enable
+
+- name: install nginx-core, no client-logging
+  become: true
+  apt:
+    name: nginx-core
+    state: "{{ bbb_state }}"
+    autoremove: true
+  when: not bbb_client_log_enable
+
 - name: install bbb and dependencies
   become: true
   apt:

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -36,3 +36,48 @@
     path: /etc/nginx/sites-enabled/default
     state: absent
   notify: reload nginx
+
+- name: copy HTML5-Client-Log location snippet
+  become: true
+  copy:
+    src: html5-client-log.nginx
+    dest: /etc/bigbluebutton/nginx/html5-client-log.nginx
+    mode: '0644'
+  when: bbb_client_log_enable
+  notify: reload nginx
+
+- name: remove HTML5-Client-Log location snippet
+  become: true
+  file:
+    path: /etc/bigbluebutton/nginx/html5-client-log.nginx
+    state: absent
+  when: not bbb_client_log_enable
+  notify: reload nginx
+
+- name: copy HTML5-Client-Log log-config snippet
+  become: true
+  copy:
+    src: html5-client-log.conf
+    dest: /etc/nginx/conf.d/html5-client-log.conf
+    mode: '0644'
+  when: bbb_client_log_enable
+  notify: reload nginx
+
+- name: remove HTML5-Client-Log location snippet
+  become: true
+  file:
+    path: /etc/nginx/conf.d/html5-client-log.conf
+    state: absent
+  when: not bbb_client_log_enable
+  notify: reload nginx
+
+- name: create HTML5-Client-Log log-file
+  become: true
+  file:
+    state: touch
+    path: /var/log/nginx/html5-client.log
+    mode: '0644'
+    owner: bigbluebutton
+    group: bigbluebutton
+  when: bbb_client_log_enable
+  notify: reload nginx


### PR DESCRIPTION
add backend for html5-client according to https://docs.bigbluebutton.org/2.2/customize.html#collect-feedback-from-the-users

With this, people can add 
```yaml
bbb_meteor:
  public:
    app:
      askForFeedbackOnLogout: true
    clientLog:
      external:
        enabled: true
        url: "https://{{ bbb_hostname }}/html5log"
```
to their config and the logs get written to `/var/log/nginx/html5-client.log`

When switching the variable "bbb_client_log_enable" to "false", the changes are reverted - only the log file is left.