### PR TITLE
fix default_presentation default naming

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -284,7 +284,7 @@
   become: true
   copy:
     src: "{{ bbb_custom_presentation }}"
-    dest: "{{ bbb_nginx_root | regex_replace('\\/$', '') }}/{{ bbb_custom_presentation_name | default(bbb_custom_presentation) }}"
+    dest: "{{ bbb_nginx_root | regex_replace('\\/$', '') }}/{{ bbb_custom_presentation_name | default('default.pdf') }}"
     mode: '0644'
   when: bbb_custom_presentation is defined
 


### PR DESCRIPTION
If bbb_custom_presentation_name is not set, the file should
be named 'default.pdf', as it is explained in README.md.