### PR TITLE
Add always tag to var checking and registering tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,7 @@
 - import_tasks: checkvars.yml
   tags:
     - checkvars
+    - always
 
 - include_tasks: check-for-sessions.yml
   when: bbb_check_for_running_meetings
@@ -38,6 +39,7 @@
 - import_tasks: runtimevars.yml
   tags:
     - runtimevars
+    - always
 
 - import_tasks: letsencrypt.yml
   when: bbb_letsencrypt_enable | bool and not bbbcert.stat.exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,10 +5,21 @@
     - checkvars
     - always
 
+- import_tasks: runtimevars.yml
+  tags:
+    - runtimevars
+    - always
+  when:
+    - not bbb_secret is defined or not bbb_baseurl is defined or not bbbcert is defined
+  ignore_errors: true
+
 - include_tasks: check-for-sessions.yml
-  when: bbb_check_for_running_meetings
+  when:
+    - bbb_check_for_running_meetings
+    - bbb_secret is defined
   tags:
     - check-for-sessions
+    - always
 
 - import_tasks: firewall/ufw_enable.yml
   when: bbb_firewall_ufw['enabled']
@@ -40,6 +51,8 @@
   tags:
     - runtimevars
     - always
+  when:
+    - not bbb_secret is defined or not bbb_baseurl is defined or not bbbcert is defined
 
 - import_tasks: letsencrypt.yml
   when: bbb_letsencrypt_enable | bool and not bbbcert.stat.exists

--- a/tasks/runtimevars.yml
+++ b/tasks/runtimevars.yml
@@ -4,6 +4,7 @@
   stat:
     path: "{{ bbb_ssl_cert }}"
   register: bbbcert
+  when: not bbbcert is defined
 
 - name: register bbb secret
   command: bbb-conf --secret


### PR DESCRIPTION
Add always tag to var checking and registering tasks since the values are needed for other tasks to run successfully.

So, even though #163 is ok, if you run a tag that requires a variable, without also running `runtimevars`, it will fail. Also, `checkvars` needs to be called to check if you have incorrect configuration.
This is why I add the always tag to those tasks, so the required variables will be available for other tasks. 

I wanted to always run `check-for-sessions` (added in #140) as well, but there is a problem there. It needs the `bbb_secret` variable, which is gathered by `runtimevars`. I don't know if we should move the `runtimevars` task before `check-for-sessions`, because that will put it before `installation` as well, likely making the role fail for first time installations. That said, was #140 checked in a fresh install? I think it will fail for `bbb_secret` not being available, but I might be wrong if is defined/ignored somewhere and I haven't noticed. 

Anyway, a solution would be to create an extra task to determine if bbb is already installed and if true we call `runtimevars` right after `checkvars`, else we run it after installation, as is now, and skip `check-for-sessions`. If you can think of a better solution please share it, otherwise I can start implementing the one I proposed.