### PR TITLE
Handle install/uninstall coturn

### DIFF
--- a/files/etc-default-coturn
+++ b/files/etc-default-coturn
@@ -1,0 +1,5 @@
+#
+# Uncomment it if you want to have the turnserver running as
+# an automatic system service daemon
+#
+TURNSERVER_ENABLED=1

--- a/tasks/coturn.yml
+++ b/tasks/coturn.yml
@@ -1,30 +1,51 @@
 ---
-- name: Install coturn
+
+- name: Manage coturn
   apt:
     name: coturn
     update_cache: true
-    state: "{{ bbb_state }}"
+    state: "{% if bbb_coturn_enable | bool %}present{% else %}absent{% endif %}"
 
 - name: Copy coturn config-file
   template:
     src: "turnserver.conf.j2"
     dest: /etc/turnserver.conf
     mode: '0644'
+  when: bbb_coturn_enable | bool
+
+- name: Remove coturn config-file
+  file:
+    path: /etc/turnserver.conf
+    state: "absent"
+  when: not (bbb_coturn_enable | bool)
 
 - name: Enable logrotate for coturn
   template:
     src: logrotate/coturn
     dest: /etc/logrotate.d/coturn
     mode: '0644'
+  when: bbb_coturn_enable | bool
+
+- name: Disable logrotate for coturn
+  file:
+    path: /etc/logrotate.d/coturn
+    state: "absent"
+  when: not (bbb_coturn_enable | bool)
 
 - name: Enable coturn server in defaults
-  lineinfile:
-    path: /etc/default/coturn
-    regexp: 'TURNSERVER_ENABLED'
-    line: 'TURNSERVER_ENABLED=1'
+  copy:
+    dest: /etc/default/coturn
+    src: etc-default-coturn
+  when: bbb_coturn_enable | bool
 
-- name: Enable coturn
+- name: Disable coturn server in defaults
+  file:
+    path: /etc/default/coturn
+    state: "absent"
+  when: not (bbb_coturn_enable | bool)
+
+- name: Manage coturn service
   service:
     name: coturn
-    enabled: true
-    state: started
+    enabled: "{{ bbb_coturn_enable | bool }}"
+    state: "{% if bbb_coturn_enable | bool %}started{% else %}stopped{% endif %}"

--- a/tasks/coturn.yml
+++ b/tasks/coturn.yml
@@ -36,6 +36,7 @@
   copy:
     dest: /etc/default/coturn
     src: etc-default-coturn
+    mode: '0644'
   when: bbb_coturn_enable | bool
 
 - name: Disable coturn server in defaults

--- a/tasks/coturn.yml
+++ b/tasks/coturn.yml
@@ -4,7 +4,7 @@
   apt:
     name: coturn
     update_cache: true
-    state: "{% if bbb_coturn_enable | bool %}present{% else %}absent{% endif %}"
+    state: "{{ 'present' if bbb_coturn_enable | bool  else 'absent' }}"
 
 - name: Copy coturn config-file
   template:
@@ -49,4 +49,4 @@
   service:
     name: coturn
     enabled: "{{ bbb_coturn_enable | bool }}"
-    state: "{% if bbb_coturn_enable | bool %}started{% else %}stopped{% endif %}"
+    state: "{{ 'started' if bbb_coturn_enable | bool else 'stopped' }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -62,7 +62,6 @@
     - ntp
 
 - import_tasks: coturn.yml
-  when: bbb_coturn_enable | bool
   tags:
     - coturn
 


### PR DESCRIPTION
Fixes #82 

If `bbb_coturn_enable` is set to false, coturn will be uninstalled and its configuration files removed.

I created a file to be copied at `/etc/default/coturn`, because uninstalling and reinstalling coturn was not creating the file again, so `lineinfile` was failing.