### PR TITLE
allow using custom greenlight docker image, fixes #138

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Also check [Before you install](https://docs.bigbluebutton.org/2.3/install.html#
 | `bbb_turn_servers` | a list of TURN-Server to use | `{{ bbb_hostname }}` with `{{ bbb_coturn_secret }}` | take a look in defaults/main.yml |
 | `bbb_greenlight_enable` | enable installation of the greenlight client | `yes` | |
 | `bbb_greenlight_hosts` | the hostname that greenlight is accessible from | `{{ bbb_hostname }}` | |
+| `bbb_greenlight_image` | the Docker image to be used for greenlight, so you can use a custom version | `bigbluebutton/greenlight:v2` | |
 | `bbb_greenlight_secret` | Secret for greenlight _(required when using greenlight)_ |  | can be generated with `openssl rand -hex 64` |
 | `bbb_greenlight_db_password` | Password for greenlight's database  _(required when using greenlight)_ | | can be generated with `openssl rand -hex 16` |
 | `bbb_greenlight_default_registration` | Registration option open(default), invite or approval | `open` | |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,6 +40,7 @@ bbb_greenlight_users: []
 bbb_webhooks_enable: false
 bbb_allow_mail_notifications: true
 bbb_greenlight_hosts: "{{ bbb_hostname }}"
+bbb_greenlight_image: bigbluebutton/greenlight:v2
 bbb_disable_recordings: false
 bbb_api_demos_enable: false
 bbb_mute_on_start: false

--- a/templates/greenlight/docker-compose.yml.j2
+++ b/templates/greenlight/docker-compose.yml.j2
@@ -3,7 +3,7 @@ version: '3'
 services:
   app:
     entrypoint: [bin/start]
-    image: bigbluebutton/greenlight:v2
+    image: "{{ bbb_greenlight_image }}"
     container_name: greenlight-v2
     env_file: .env
     restart: unless-stopped


### PR DESCRIPTION
Doesn't address how the docker image will get to the destination host, but allows to change it to a custom one.