### PR TITLE
fix failing coturn tasks if coturn is not installed

### DIFF
--- a/tasks/coturn.yml
+++ b/tasks/coturn.yml
@@ -49,4 +49,5 @@
   service:
     name: coturn
     enabled: "{{ bbb_coturn_enable | bool }}"
-    state: "{{ 'started' if bbb_coturn_enable | bool else 'stopped' }}"
+    state: started
+  when: bbb_coturn_enable | bool


### PR DESCRIPTION
If coturn is not installed, the service can neigther be stopped
or started. Instead the coturn service should just be started
when bbb_coturn_enable is true.