### PR TITLE
fix: removed 'is' from conditonal

### DIFF
--- a/tasks/check-for-sessions.yml
+++ b/tasks/check-for-sessions.yml
@@ -16,5 +16,5 @@
     when:
       - not ansible_check_mode
       - bbb_getmeetings.status == 200
-      - "'<messageKey>noMeetings</messageKey>' is not in bbb_getmeetings.content"
+      - "'<messageKey>noMeetings</messageKey>' not in bbb_getmeetings.content"
     tags: always


### PR DESCRIPTION
```
The conditional check ''<messageKey>noMeetings</messageKey>' is not in bbb_getmeetings.content' failed. The error was: template error while templating string: expected token 'end of statement block', got '.'. String: {% if '<messageKey>noMeetings</messageKey>' is not in bbb_getmeetings.content %} True {% else %} False {% endif %}
```