### PR TITLE
Add community.general to the requirements

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,7 @@
 ---
-- src: geerlingguy.nodejs
-- src: geerlingguy.docker
+roles:
+  - src: geerlingguy.nodejs
+  - src: geerlingguy.docker
+
+collections:
+  - name: community.general


### PR DESCRIPTION
This fixes https://github.com/ebbba-org/ansible-role-bigbluebutton/issues/196 that adds the community.general collection to the requirements of the role.