### PR TITLE
Fix check mode

### DIFF
--- a/tasks/bbb_secret.yml
+++ b/tasks/bbb_secret.yml
@@ -5,6 +5,7 @@
       become: true
       command: bbb-conf --secret
       changed_when: false
+      check_mode: no
       register: result
 
     - name: parse bbb secret

--- a/tasks/bbb_secret.yml
+++ b/tasks/bbb_secret.yml
@@ -5,7 +5,7 @@
       become: true
       command: bbb-conf --secret
       changed_when: false
-      check_mode: no
+      check_mode: false
       register: result
 
     - name: parse bbb secret

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -32,6 +32,7 @@
 - name: register bbb secret
   command: bbb-conf --secret
   changed_when: false
+  check_mode: false
   register: result
 
 - name: parse bbb secret


### PR DESCRIPTION
Ansible does not run commands in check_mode. While this is useful in most cases (commands can change something in the system, but ansible can not know if it does), this breaks the whole possibility of running the role (or parts of it) in check_mode, since bbb_secret is tagged with 'always'.
We can safely run bbb-conf --secret in check_mode to fix it (this command does not change anything).