### PR TITLE
Restart coturn after coturn config change

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -77,6 +77,12 @@
     name: apparmor
     state: reloaded
 
+- name: restart coturn
+  become: true
+  systemd:
+    name: coturn
+    state: restarted
+
 - name: restart monitoring container
   docker_compose:
     pull: false

--- a/tasks/coturn.yml
+++ b/tasks/coturn.yml
@@ -12,6 +12,7 @@
     dest: /etc/turnserver.conf
     mode: '0644'
   when: bbb_coturn_enable | bool
+  notify: restart coturn
 
 - name: Remove coturn config-file
   file:
@@ -38,6 +39,7 @@
     src: etc-default-coturn
     mode: '0644'
   when: bbb_coturn_enable | bool
+  notify: restart coturn
 
 - name: Disable coturn server in defaults
   file:


### PR DESCRIPTION
Currently, if you e.g. change the coturn port or enable coturn for the first time, it will not trigger a restart of the service. This PR attempts to fix that.