### PR TITLE
[feat] configure correct number of poolhtml5servers

### DIFF
--- a/tasks/bbb-html5.yml
+++ b/tasks/bbb-html5.yml
@@ -44,3 +44,10 @@
     mode: '0644'
   notify:
     - restart bbb-web
+
+- name: setup html5-frontend nginx connections
+  template:
+    src: nginx/bbb-html5-loadbalancer.conf.j2
+    dest: /etc/nginx/conf.d/bbb-html5-loadbalancer.conf
+    mode: '0644'
+  notify: reload nginx

--- a/templates/nginx/bbb-html5-loadbalancer.conf.j2
+++ b/templates/nginx/bbb-html5-loadbalancer.conf.j2
@@ -1,0 +1,7 @@
+upstream poolhtml5servers {
+  zone poolhtml5servers 32k;
+  least_conn;
+{% for i in range(bbb_html5_frontend_processes | default(2) | int(2)) %}
+  server 127.0.0.1:410{{ i }} fail_timeout=5s max_fails=3;
+{% endfor %}
+}


### PR DESCRIPTION
At the moment /etc/nginx/conf.d/bbb-html5-loadbalancer.conf is statically provided by bbb-html5.
While the number of NodeJS processes can be customized
(see https://docs.bigbluebutton.org/dev/dev23.html#increase-number-of-processes-for-nodejs),
as of right now the config file always comes preconfigured for 8 processes.

Since we already know how many html5-frontend processes will be
configured (see bbb_html5_frontend_processes in defaults/main.yml), we
can configure the nginx config (bbb-html5-loadbalancer.conf) approprietly.

This is a solution to https://github.com/bigbluebutton/bigbluebutton/issues/12291