### PR TITLE
nginx: make creation of client-log idempotent

### DIFF
--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -75,6 +75,8 @@
   become: true
   file:
     state: touch
+    access_time: preserve
+    modification_time: preserve
     path: /var/log/nginx/html5-client.log
     mode: '0644'
     owner: bigbluebutton

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -79,7 +79,7 @@
     modification_time: preserve
     path: /var/log/nginx/html5-client.log
     mode: '0644'
-    owner: bigbluebutton
-    group: bigbluebutton
+    owner: www-data
+    group: adm
   when: bbb_client_log_enable
   notify: reload nginx


### PR DESCRIPTION
The task "create HTML5-Client-Log log-file" is not idempotent at the moment, since it touches the log-file in each ansible-run.
This can be avoided by using
```yaml
    access_time: preserve
    modification_time: preserve
```
in the task.