### PR TITLE
nginx: fully align with nginx logrotate config

### DIFF
--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -78,7 +78,7 @@
     access_time: preserve
     modification_time: preserve
     path: /var/log/nginx/html5-client.log
-    mode: '0644'
+    mode: '0640'
     owner: www-data
     group: adm
   when: bbb_client_log_enable


### PR DESCRIPTION
I forgot to align file mode of html5-client.log  in last PR (#224).
This is to prevent unnecessary  "changes" by ansible.