### PR TITLE
Extended bbb_dialin_default_play_and_get_digits variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Also check [Before you install](https://docs.bigbluebutton.org/2.3/install.html#
 | | `bbb_dialin_provider_extension` | Extension of your SIP account | `6135551234` | |
 | | `bbb_dialin_default_number` | Number to present to users for dial-in. Enable `bbb_dialin_overwrite_footer` or use `%%DIALNUM%%` and `%%CONFNUM%%` in you footer (see `bbb_default_welcome_message_footer`) | `6135551234` | |
 | | `bbb_dialin_mask_caller` | Mask caller-number in the BBB web-interface for privacy reasons (`01711233121` → `xxx-xxx-3121`) | |
-| | `bbb_dialin_default_play_and_get_digits` | Phone dialin-pin entry voice dialog | `5 5 3 7000 # conference/conf-pin.wav ivr/ivr-that_was_an_invalid_entry.wav pin \d+` | Usage `<min> <max> <tries> <timeout> <terminators>` See [this](https://freeswitch.org/confluence/display/FREESWITCH/mod_dptools%3A+play_and_get_digits) for more details |
+| | `bbb_dialin_default_play_and_get_digits` | Phone dialin-pin entry voice dialog | `5 5 3 7000 # conference/conf-pin.wav ivr/ivr-that_was_an_invalid_entry.wav pin \\d+` | Usage `<min> <max> <tries> <timeout> <terminators>` See [this](https://freeswitch.org/confluence/display/FREESWITCH/mod_dptools%3A+play_and_get_digits) for more details |
 | | `bbb_dialin_overwrite_footer` | Set the default dial-in footer instead of `bbb_default_welcome_message_footer` | `false` | |
 | | `bbb_dialin_footer` | The default dial-in notice, if you want to customize it, it is recommended to change `bbb_default_welcome_message_footer` instead | `<br><br>To join this meeting by phone, dial:<br>  %%DIALNUM%%<br>Then enter %%CONFNUM%% as the conference PIN number.` | |
 | | `bbb_guestpolicy` | How guest can access | `ALWAYS_ACCEPT` | acceptable options: ALWAYS_ACCEPT, ALWAYS_DENY, ASK_MODERATOR | |

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Also check [Before you install](https://docs.bigbluebutton.org/2.3/install.html#
 | | `bbb_dialin_provider_extension` | Extension of your SIP account | `6135551234` | |
 | | `bbb_dialin_default_number` | Number to present to users for dial-in. Enable `bbb_dialin_overwrite_footer` or use `%%DIALNUM%%` and `%%CONFNUM%%` in you footer (see `bbb_default_welcome_message_footer`) | `6135551234` | |
 | | `bbb_dialin_mask_caller` | Mask caller-number in the BBB web-interface for privacy reasons (`01711233121` → `xxx-xxx-3121`) | |
-| | `bbb_dialin_default_play_and_get_digits` | Phone dialin-pin entry voice dialog | `5 5 3 7000 #` | Usage `<min> <max> <tries> <timeout> <terminators>` See [this](https://freeswitch.org/confluence/display/FREESWITCH/mod_dptools%3A+play_and_get_digits) for more details | 
+| | `bbb_dialin_default_play_and_get_digits` | Phone dialin-pin entry voice dialog | `5 5 3 7000 # conference/conf-pin.wav ivr/ivr-that_was_an_invalid_entry.wav pin \d+` | Usage `<min> <max> <tries> <timeout> <terminators>` See [this](https://freeswitch.org/confluence/display/FREESWITCH/mod_dptools%3A+play_and_get_digits) for more details |
 | | `bbb_dialin_overwrite_footer` | Set the default dial-in footer instead of `bbb_default_welcome_message_footer` | `false` | |
 | | `bbb_dialin_footer` | The default dial-in notice, if you want to customize it, it is recommended to change `bbb_default_welcome_message_footer` instead | `<br><br>To join this meeting by phone, dial:<br>  %%DIALNUM%%<br>Then enter %%CONFNUM%% as the conference PIN number.` | |
 | | `bbb_guestpolicy` | How guest can access | `ALWAYS_ACCEPT` | acceptable options: ALWAYS_ACCEPT, ALWAYS_DENY, ASK_MODERATOR | |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -108,7 +108,7 @@ bbb_dialin_provider_username: "provider-account"
 bbb_dialin_provider_password: "provider-password"
 bbb_dialin_provider_extension: "6135551234"
 bbb_dialin_default_number: "613-555-1234"
-bbb_dialin_default_play_and_get_digits: "5 5 3 7000 #"
+bbb_dialin_default_play_and_get_digits: "5 5 3 7000 # conference/conf-pin.wav ivr/ivr-that_was_an_invalid_entry.wav pin \d+"
 bbb_dialin_mask_caller: false
 bbb_dialin_overwrite_footer: false
 bbb_dialin_footer: <br><br>To join this meeting by phone, dial:<br>  %%DIALNUM%%<br>Then enter %%CONFNUM%% as the conference PIN number.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -102,7 +102,7 @@ bbb_monitoring_systemd_bind_ip: 0.0.0.0
 bbb_monitoring_systemd_port: 9688
 
 bbb_dialin_enabled: false
-bbb_dialin_provider_proxy: "sip.example.net"<
+bbb_dialin_provider_proxy: "sip.example.net"
 bbb_dialin_provider_ip: ""
 bbb_dialin_provider_username: "provider-account"
 bbb_dialin_provider_password: "provider-password"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -102,13 +102,13 @@ bbb_monitoring_systemd_bind_ip: 0.0.0.0
 bbb_monitoring_systemd_port: 9688
 
 bbb_dialin_enabled: false
-bbb_dialin_provider_proxy: "sip.example.net"
+bbb_dialin_provider_proxy: "sip.example.net"<
 bbb_dialin_provider_ip: ""
 bbb_dialin_provider_username: "provider-account"
 bbb_dialin_provider_password: "provider-password"
 bbb_dialin_provider_extension: "6135551234"
 bbb_dialin_default_number: "613-555-1234"
-bbb_dialin_default_play_and_get_digits: "5 5 3 7000 # conference/conf-pin.wav ivr/ivr-that_was_an_invalid_entry.wav pin \d+"
+bbb_dialin_default_play_and_get_digits: "5 5 3 7000 # conference/conf-pin.wav ivr/ivr-that_was_an_invalid_entry.wav pin \\d+"
 bbb_dialin_mask_caller: false
 bbb_dialin_overwrite_footer: false
 bbb_dialin_footer: <br><br>To join this meeting by phone, dial:<br>  %%DIALNUM%%<br>Then enter %%CONFNUM%% as the conference PIN number.

--- a/templates/dial-in/dialplan.xml.j2
+++ b/templates/dial-in/dialplan.xml.j2
@@ -2,7 +2,7 @@
  <condition field="destination_number" expression="^{{ bbb_dialin_provider_extension }}">
    <action application="answer"/>
    <action application="sleep" data="1000"/>
-   <action application="play_and_get_digits" data="{{ bbb_dialin_default_play_and_get_digits }} conference/conf-pin.wav ivr/ivr-that_was_an_invalid_entry.wav pin \d+"/>
+   <action application="play_and_get_digits" data="{{ bbb_dialin_default_play_and_get_digits }}"/>
 
    <!-- Uncomment the following block if you want to mask the phone number in the list of participants. -->
    <!-- Instead of `01711233121` it will then show `xxx-xxx-3121`. -->


### PR DESCRIPTION
This feature request will allow to use customize dail-in announces.

e.g. 5 5 3 7000 # ivr/ivr-please_enter_pin_followed_by_pound.wav ivr/ivr-that_was_an_invalid_entry.wav pin \d+ to acconce to use the pound sign