### PR TITLE
Add bbb_dialplan vars to fs conference.conf template

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Also check [Before you install](https://docs.bigbluebutton.org/2.3/install.html#
 | | `bbb_recording_config` | overwrite recording settings | `{}` | See [Enable playback of recordings on iOS](https://docs.bigbluebutton.org/admin/customize.html#enable-playback-of-recordings-on-ios). It works like `bbb_meteor` by merging your custom config with the server config. |
 | | `bbb_dialplan_quality` | Set quality of dailplan for FreeSWITCH | `cdquality` | |
 | | `bbb_dialplan_energy_level` | Set energy level of dailplan for FreeSWITCH | `100` | only for selected profile `bbb_dialplan_quality` |
-| | `bbb_dialplan_comfort_noise` | Set comfort noise of dailplan for FreeSWITCH | `1400` | only for selected profile `bbb_dialplan_quality` |
+| | `bbb_dialplan_comfort_noise` | Set comfort noise of dailplan for FreeSWITCH | `1400` | Allowed values: (0-10000|true), 0 disables comfort-noise, true sets to default (1400), only for selected profile `bbb_dialplan_quality` |
 | | `bbb_webhooks_enable` | install bbb-webhooks | `no` | |
 | | `bbb_check_for_running_meetings` | Check server and stop playbook in case of running meetings. Attention: Currently the check is done only after Docker and NodeJS Roles have already run. | `true` | |
 | | `bbb_monitoring_all_in_one_enable` | deploy [all in one monitoring stack](https://bigbluebutton-exporter.greenstatic.dev/installation/all_in_one_monitoring_stack/) (docker) | `no` |

--- a/tasks/freeswitch.yml
+++ b/tasks/freeswitch.yml
@@ -144,24 +144,6 @@
     replace: '<action application="conference" data="${vbridge}@{{ bbb_dialplan_quality }}"/>'
   notify: restart freeswitch
 
-- name: FreeSWITCH dialplan energy-level
-  replace:
-    path: /opt/freeswitch/etc/freeswitch/autoload_configs/conference.conf.xml
-    after: '<profile name="{{ bbb_dialplan_quality }}">'
-    before: '</profile>'
-    regexp: '<param name="energy-level" value=".*"\/>'
-    replace: '<param name="energy-level" value="{{ bbb_dialplan_energy_level }}"/>'
-  notify: restart freeswitch
-
-- name: FreeSWITCH dialplan comfort-noise
-  replace:
-    path: /opt/freeswitch/etc/freeswitch/autoload_configs/conference.conf.xml
-    after:   '<profile name="{{ bbb_dialplan_quality }}">'
-    before:  '</profile>'
-    regexp:  '<param name="comfort-noise" value=".*"\/>'
-    replace: '<param name="comfort-noise" value="{{ bbb_dialplan_comfort_noise }}"/>'
-  notify: restart freeswitch
-
 - name: FreeSWITCH external ip (rtp)
   replace:
     path: /opt/freeswitch/etc/freeswitch/vars.xml

--- a/templates/freeswitch/conference.conf.xml
+++ b/templates/freeswitch/conference.conf.xml
@@ -43,7 +43,7 @@
       <!-- Number of milliseconds per frame -->
       <param name="interval" value="20"/>
       <!-- Energy level required for audio to be sent to the other users -->
-      <param name="energy-level" value="100"/>
+      <param name="energy-level" value="{{ bbb_dialplan_energy_level if bbb_dialplan_quality == 'default' else 100 }}"/>
 
       <!--Can be | delim of waste|mute|deaf|dist-dtmf waste will always transmit data to each channel
           even during silence.  dist-dtmf propagates dtmfs to all other members, but channel controls
@@ -114,7 +114,7 @@
       <!-- Suppress start and stop talking events -->
       <!-- <param name="suppress-events" value="start-talking,stop-talking"/> -->
       <!-- enable comfort noise generation -->
-      <!-- <param name="comfort-noise" value="true"/> -->
+      <param name="comfort-noise" value="{{ bbb_dialplan_comfort_noise if bbb_dialplan_quality == 'default' else 'true' }}"/>
       <!-- Uncomment auto-record to toggle recording every conference call. -->
       <!-- Another valid value is   shout://user:pass@server.com/live.mp3   -->
       <!--
@@ -140,7 +140,7 @@
       <param name="domain" value="$${domain}"/>
       <param name="rate" value="16000"/>
       <param name="interval" value="20"/>
-      <param name="energy-level" value="100"/>
+      <param name="energy-level" value="{{ bbb_dialplan_energy_level if bbb_dialplan_quality == 'wideband' else 100 }}"/>
       <!-- <param name="sound-prefix" value="$${sounds_dir}/en/us/callie"/> -->
       <param name="muted-sound" value="conference/conf-muted.wav"/>
       <param name="unmuted-sound" value="conference/conf-unmuted.wav"/>
@@ -156,7 +156,7 @@
       <param name="bad-pin-sound" value="conference/conf-bad-pin.wav"/>
       <param name="caller-id-name" value="$${outbound_caller_name}"/>
       <param name="caller-id-number" value="$${outbound_caller_id}"/>
-      <!-- <param name="comfort-noise" value="true"/> -->
+      <param name="comfort-noise" value="{{ bbb_dialplan_comfort_noise if bbb_dialplan_quality == 'wideband' else 'true' }}"/>
       <!-- <param name="tts-engine" value="flite"/> -->
       <!-- <param name="tts-voice" value="kal16"/> -->
     </profile>
@@ -165,7 +165,7 @@
       <param name="domain" value="$${domain}"/>
       <param name="rate" value="32000"/>
       <param name="interval" value="20"/>
-      <param name="energy-level" value="100"/>
+      <param name="energy-level" value="{{ bbb_dialplan_energy_level if bbb_dialplan_quality == 'ultrawideband' else 100 }}"/>
       <!-- <param name="sound-prefix" value="$${sounds_dir}/en/us/callie"/> -->
       <param name="muted-sound" value="conference/conf-muted.wav"/>
       <param name="unmuted-sound" value="conference/conf-unmuted.wav"/>
@@ -181,7 +181,7 @@
       <param name="bad-pin-sound" value="conference/conf-bad-pin.wav"/>
       <param name="caller-id-name" value="$${outbound_caller_name}"/>
       <param name="caller-id-number" value="$${outbound_caller_id}"/>
-      <!-- <param name="comfort-noise" value="true"/> -->
+      <param name="comfort-noise" value="{{ bbb_dialplan_comfort_noise if bbb_dialplan_quality == 'ultrawideband' else 'true' }}"/>
 
       <!-- <param name="conference-flags" value="video-floor-only|rfc-4579|livearray-sync|auto-3d-position|transcode-video|minimize-video-encoding"/> -->
 
@@ -204,7 +204,7 @@
       <param name="domain" value="$${domain}"/>
       <param name="rate" value="48000"/>
       <param name="interval" value="20"/>
-      <param name="energy-level" value="100"/>
+      <param name="energy-level" value="{{ bbb_dialplan_energy_level if bbb_dialplan_quality == 'cdquality' else 1400 }}"/>
       <!-- <param name="sound-prefix" value="$${sounds_dir}/en/us/callie"/> -->
       <!-- File to play to acknowledge muted -->
       {% if bbb_freeswitch_muted_sound == true -%}
@@ -230,8 +230,7 @@
       <param name="bad-pin-sound" value="conference/conf-bad-pin.wav"/>
       <param name="caller-id-name" value="$${outbound_caller_name}"/>
       <param name="caller-id-number" value="$${outbound_caller_id}"/>
-      <!-- param name="comfort-noise" value="true"/ -->
-      <!-- <param name="comfort-noise" value="1400"/> -->
+      <param name="comfort-noise" value="{{ bbb_dialplan_comfort_noise if bbb_dialplan_quality == 'cdquality' else 100 }}"/>
       <param name="video-auto-floor-msec" value="2000"/>
 
       <!-- <param name="conference-flags" value="video-floor-only|rfc-4579|livearray-sync|auto-3d-position|minimize-video-encoding"/> -->
@@ -252,7 +251,7 @@
       <param name="rate" value="48000"/>
       <param name="channels" value="2"/>
       <param name="interval" value="20"/>
-      <param name="energy-level" value="100"/>
+      <param name="energy-level" value="{{ bbb_dialplan_energy_level if bbb_dialplan_quality == 'video-mcu-stereo' else 100 }}"/>
       <!-- <param name="tts-engine" value="flite"/> -->
       <!-- <param name="tts-voice" value="kal16"/> -->
       <param name="muted-sound" value="conference/conf-muted.wav"/>
@@ -269,7 +268,7 @@
       <param name="bad-pin-sound" value="conference/conf-bad-pin.wav"/>
       <param name="caller-id-name" value="$${outbound_caller_name}"/>
       <param name="caller-id-number" value="$${outbound_caller_id}"/>
-      <!-- <param name="comfort-noise" value="false"/> -->
+      <param name="comfort-noise" value="false"/>
       <param name="conference-flags" value="video-floor-only|rfc-4579|livearray-sync|minimize-video-encoding"/>
       <param name="video-mode" value="mux"/>
       <param name="video-layout-name" value="3x3"/>


### PR DESCRIPTION
Use bbb_dialplan_energy_level and bbb_dialplan_comfort_noise
in freeswitch conference.conf.xml template and remove unnecessary
tasks for this in task/freeswitch.yml.

bbb_dialplan_comfort_noise (defined in defaults/main.yml) was not used effectively, since all occurences of param comfort-noise were commented out.

This PR follows upstream as of https://github.com/bigbluebutton/bigbluebutton/blob/develop/bbb-voice-conference/config/freeswitch/conf/autoload_configs/conference.conf.xml.