### PR TITLE
fix managing freeswitch ipv6-profiles with command

### DIFF
--- a/tasks/freeswitch.yml
+++ b/tasks/freeswitch.yml
@@ -119,7 +119,7 @@
 
     - name: manage ipv6 sip_profiles
       become: true
-      ansible.builtin.command: |
+      command: >
         mv
           "{{ sip_profile.item + '.disabled' if bbb_freeswitch_ipv6 | bool else sip_profile.item }}"
           "{{ sip_profile.item if bbb_freeswitch_ipv6 | bool else sip_profile.item + '.disabled' }}"


### PR DESCRIPTION
closes #239

This is just a strange bug in ansible:
https://github.com/ansible/ansible/issues/72295
https://github.com/ansible/ansible/issues/71817