### PR TITLE
bbb_greenlight_users fix

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,13 +36,13 @@ bbb_turn_servers:
 
 bbb_greenlight_enable: true
 bbb_greenlight_users: []
-  # - name: '' 
-  #   email: '' 
-  #   password: '' 
-  #   type: 'user' 
-  # - name: '' 
-  #   email: '' 
-  #   password: '' 
+  # - name: ''
+  #   email: ''
+  #   password: ''
+  #   type: 'user'
+  # - name: ''
+  #   email: ''
+  #   password: ''
   #   type: 'admin'
 
 bbb_webhooks_enable: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,8 +36,14 @@ bbb_turn_servers:
 
 bbb_greenlight_enable: true
 bbb_greenlight_users: []
-#  - { name: '', email: '', password: '', type: 'user' }
-#  - { name: '', email: '', password: '', type: 'admin' }
+  # - name: '' 
+  #   email: '' 
+  #   password: '' 
+  #   type: 'user' 
+  # - name: '' 
+  #   email: '' 
+  #   password: '' 
+  #   type: 'admin'
 
 bbb_webhooks_enable: false
 bbb_allow_mail_notifications: true

--- a/examples/vars.yml
+++ b/examples/vars.yml
@@ -14,8 +14,14 @@
 #bbb_greenlight_secret: <secret> # Uncomment, generate and fill using `openssl rand -hex 64`, when using greenlight
 #bbb_greenlight_db_password: <secret> # Uncomment, generate and fill using `openssl rand -hex 16`, when using greenlight
 #bbb_greenlight_users: # Uncomment and fill if using greenlight, to create users
-#  - { name: '', email: '', password: '', type: 'user' }
-#  - { name: '', email: '', password: '', type: 'admin' }
+# - name: '' 
+#   email: '' 
+#   password: '' 
+#   type: 'user' 
+# - name: '' 
+#   email: '' 
+#   password: '' 
+#   type: 'admin'
 
 # FREESWITCH
 bbb_freeswitch_socket_password: "<secret>" # Generate and fill using `pwgen -s 16 1`

--- a/examples/vars.yml
+++ b/examples/vars.yml
@@ -14,14 +14,14 @@
 #bbb_greenlight_secret: <secret> # Uncomment, generate and fill using `openssl rand -hex 64`, when using greenlight
 #bbb_greenlight_db_password: <secret> # Uncomment, generate and fill using `openssl rand -hex 16`, when using greenlight
 #bbb_greenlight_users: # Uncomment and fill if using greenlight, to create users
-# - name: '' 
-#   email: '' 
-#   password: '' 
-#   type: 'user' 
-# - name: '' 
-#   email: '' 
-#   password: '' 
-#   type: 'admin'
+#  - name: ''
+#    email: ''
+#    password: ''
+#    type: 'user'
+#  - name: ''
+#    email: ''
+#    password: ''
+#    type: 'admin'
 
 # FREESWITCH
 bbb_freeswitch_socket_password: "<secret>" # Generate and fill using `pwgen -s 16 1`

--- a/tasks/greenlight.yml
+++ b/tasks/greenlight.yml
@@ -40,7 +40,7 @@
     # https://docs.bigbluebutton.org/greenlight/gl-admin.html#creating-accounts
     - name: Create greenlight users
       command: "docker exec greenlight-v2 bundle exec rake user:create[\"{{ item.name }}\",\"{{ item.email }}\",\"{{ item.password }}\",\"{{ item.type }}\"]"
-      loop: "{{ bbb_greenlight_users | flatten(levels=1) }}"
+      loop: "{{ bbb_greenlight_users }}"
       register: usercreate
       failed_when: "'Invalid Arguments' in usercreate.stdout"
       changed_when: "'Account with that email already exists' not in usercreate.stdout"

--- a/test/integration/default/default.yml
+++ b/test/integration/default/default.yml
@@ -15,7 +15,10 @@
     bbb_letsencrypt_email: mail@example.com
     bbb_greenlight_enable: true
     bbb_greenlight_users:
-      - { name: 'user1', email: 'user1@example.com', password: 'user1@example.com', type: 'user' }
+      - name: 'user1'
+        email: 'user1@example.com'
+        password: 'user1@example.com'
+        type: 'user'
   pre_tasks:
     - name: Bionic+ | Set mongodb to 4.2
       set_fact:


### PR DESCRIPTION
somehow the current config with bbb_greenlight_users array set to 
`- { name: '', email: '', password: '', type: 'user' } `
and then use this array with 
`| flatten(levels=1)` in `the Create greenlight users` task leads to the ansible task result "changed":

`TASK [ebbba.bigbluebutton : Create greenlight users] ***************************
changed: [server] => (item={u'password': u'secret', u'type': u'admin', u'name': u'admin', u'email': u'email@company.tld'})`

but the login with the defined credentials is not possible afterwards.

also in the database the user is not contained after this step, checked it with

 `docker exec greenlight-v2 psql "postgresql://postgres:<hereyourpw>@db:5432/<hereyourdbname>" -c "select * from users;" `

but with a "real" array and without flatten filter, it works fine. Maybe the order of the attributes gets mixed by the flatten filter?


