### PR TITLE
wait until rake did all necessary migrations before greenlight user creation

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -7,3 +7,4 @@ roles:
 
 collections:
   - name: community.general
+  - name: community.docker

--- a/tasks/greenlight.yml
+++ b/tasks/greenlight.yml
@@ -37,12 +37,23 @@
         pull: "{{ bbb_greenlight_image_pull }}"
         project_src: /root/greenlight/
 
+    - name: wait until rake did all necessary migrations
+      community.docker.docker_container_exec:
+        container: greenlight-v2
+        command: bundle exec rake db:abort_if_pending_migrations
+      register: greenlight_rake
+      until: greenlight_rake.rc == 0
+      retries: 10
+      when: not ansible_check_mode
+
     # https://docs.bigbluebutton.org/greenlight/gl-admin.html#creating-accounts
     - name: Create greenlight users
-      command: "docker exec greenlight-v2 bundle exec rake user:create[\"{{ item.name }}\",\"{{ item.email }}\",\"{{ item.password }}\",\"{{ item.type }}\"]"
+      community.docker.docker_container_exec:
+        container: greenlight-v2
+        command: "bundle exec rake user:create[\"{{ item.name }}\",\"{{ item.email }}\",\"{{ item.password }}\",\"{{ item.type }}\"]"
       loop: "{{ bbb_greenlight_users | flatten(levels=1) }}"
       register: usercreate
       failed_when: "'Invalid Arguments' in usercreate.stdout"
-      changed_when: "'Account with that email already exists' not in usercreate.stdout"
+      changed_when: "'Account successfully created' in usercreate.stdout"
 
   when: bbb_greenlight_enable | bool


### PR DESCRIPTION
the root cause of not created users is, like mentioned [here](https://github.com/ebbba-org/ansible-role-bigbluebutton/pull/260), that rake did not create all tables yet when the user is created.

so this MR waits until rake is done, then the user creation works fine.