### PR TITLE
Add cache_valid_time to apt tasks with update_cache

### DIFF
--- a/tasks/certificate-letsencrypt.yml
+++ b/tasks/certificate-letsencrypt.yml
@@ -12,6 +12,7 @@
       - certbot
       - python3-certbot-nginx
     update_cache: true
+    cache_valid_time: 60
     state: "{{ bbb_state }}"
 
 - name: Set Let's Encrypt API

--- a/tasks/certificate.yml
+++ b/tasks/certificate.yml
@@ -6,6 +6,7 @@
     pkg:
       - ssl-cert
     update_cache: true
+    cache_valid_time: 60
     state: "{{ bbb_state }}"
 
 - import_tasks: certificate-letsencrypt.yml

--- a/tasks/coturn.yml
+++ b/tasks/coturn.yml
@@ -4,6 +4,7 @@
   apt:
     name: coturn
     update_cache: true
+    cache_valid_time: 60
     state: "{{ 'present' if bbb_coturn_enable | bool  else 'absent' }}"
 
 - name: Copy coturn config-file

--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -5,6 +5,7 @@
   apt:
     name: "{{ bbb_required_packages }}"
     update_cache: true
+    cache_valid_time: 60
 
 - name: set version of java to use
   become: true


### PR DESCRIPTION
Apt-cache doesn't need to be updated several times during one role-run.
This commit improves runtime of role-runs.