### PR TITLE
use bbb_default_logo_url as branding image setting

### DIFF
--- a/tasks/greenlight.yml
+++ b/tasks/greenlight.yml
@@ -56,4 +56,11 @@
       failed_when: "'Invalid Arguments' in usercreate.stdout"
       changed_when: "'Account successfully created' in usercreate.stdout"
 
+    - name: Set greenlight branding image
+      community.docker.docker_container_exec:
+        container: greenlight-v2
+        command: "bundle exec rails runner 'Setting.create(provider: \"greenlight\") if Setting.count.zero?; Setting.first.update_value(\"Branding Image\", \"{{ bbb_default_logo_url }}\")'"
+      when: bbb_use_default_logo
+      changed_when: true
+
   when: bbb_greenlight_enable | bool


### PR DESCRIPTION
This MR sets the bbb_default_logo_url, if the bbb_use_default_logo is set to true, as the branding image, so that on the start page of bbb the logo is visible too.