### PR TITLE
fix ordering of handlers execution; fixes #282

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -16,14 +16,6 @@
     name: nginx
     state: restarted
 
-- name: set bbb hostname
-  become: true
-  command: "bbb-conf --setip {{ bbb_hostname }}"
-
-- name: restart bigbluebutton
-  become: true
-  command: bbb-conf --restart
-
 - name: restart freeswitch
   become: true
   systemd:
@@ -94,3 +86,12 @@
     name: etherpad.service
     enabled: true
     state: restarted
+
+- name: set bbb hostname
+  become: true
+  command: "bbb-conf --setip {{ bbb_hostname }}"
+
+# This should be the last handler. In case it is necessary that bbb is restarted all togehter.
+- name: restart bigbluebutton
+  become: true
+  command: bbb-conf --restart


### PR DESCRIPTION
Set the `restart bigbluebutton` handler to the lowest position in handlers/main.yml, to ensure, that, if multiple handlers (including `restart bigbluebutton`) were called, bbb will be restarted all-together in the end.
I tested this PR successfully. Before the change, I encountered #282 certainly.