### PR TITLE
Allow replacing default logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Also check [Before you install](https://docs.bigbluebutton.org/2.4/install.html#
 | | `bbb_custom_presentation_name` | Set a custom presentation name | `None` | Instead of overwriting the `default.pdf` setting the name will add for example the `customer.pdf` |
 | | `bbb_use_default_logo` | Determines if a default-logo should be used if api-parameter "logo" is not used | `false` | The (default) logo is displayed at the top left corner. |
 | | `bbb_default_logo_url` | Set a URL for the default logo | `${bigbluebutton.web.serverURL}/images/logo.png` | |
+| | `bbb_custom_logo` | Overwrite default logo.png | `None` | Location of a custom presentation will be renamed to `logo.png` if `bbb_custom_logo_name` is not defined - see [Ansible search paths](https://docs.ansible.com/ansible/latest/user_guide/playbook_pathing.html) for where to place your custom png - Example `playbooks/files/logo.png` |
+| | `bbb_custom_logo_name` | Set a custom logo name | `None` | Instead of overwriting the `logo.png` setting the name will add for example the `custom-logo.png` |
 | | `bbb_web_logouturl` | set logout URL | `default` | Instead of using `bigbluebutton.web.serverURL` as default logout page, set another URL or customize logout page e.g. ${bigbluebutton.web.serverURL}/logout.html. API create call with the `logoutURL` parameter overwrite this setting |
 | | `bbb_allow_request_without_session` | Enable or disable allow request without session | `false` | Allow requests without JSESSIONID to be handled |
 | | `bbb_turn_enable` | enable the use uf TURN in general | `yes` | |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -159,7 +159,9 @@ bbb_kurento_interfaces:
 - "{{ ansible_default_ipv4.interface }}"
 - lo
 
-bbb_webrtc_sfu_multikurento:
+# Define default as "internal" variable, as to allow using combine() on this.
+# That way we can add to the default values while redefining 'bbb_webrtc_sfu_multikurento'.
+_bbb_webrtc_sfu_multikurento:
   balancing-strategy: MEDIA_TYPE
   kurento:
     - ip: "{{ ansible_default_ipv4.address }}"
@@ -202,6 +204,10 @@ bbb_webrtc_sfu_multikurento:
   log:
     level: warn
     filename:
+
+# Put default values into actual variable.
+bbb_webrtc_sfu_multikurento: "{{ _bbb_webrtc_sfu_multikurento }}"
+
 
 # Skip all tasks that are incompatible with (unprivileged) containers
 bbb_container_compat: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -148,7 +148,10 @@ bbb_default_meeting_layout: 'SMART_LAYOUT'
 bbb_webcams_only_for_moderator: false
 
 bbb_use_default_logo: false
-bbb_default_logo_url: '${bigbluebutton.web.serverURL}/images/logo.png'
+bbb_default_logo_url: "${bigbluebutton.web.serverURL}/images/{{ bbb_custom_logo_name | default ('logo.png') }}"
+# bbb_custom_logo: "logo.png"
+# set this to the name the default logo on the host should have.
+# bbb_custom_logo_name: "logo.png"
 
 bbb_etherpad_disable_cursortrace_plugin: false
 

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -192,6 +192,14 @@
     mode: '0644'
   when: bbb_custom_presentation is defined
 
+- name: set custom logo
+  become: true
+  copy:
+    src: "{{ bbb_custom_logo }}"
+    dest: "{{ bbb_nginx_root | regex_replace('\\/$', '') }}/{{ bbb_custom_logo_name | default('logo.png') }}"
+    mode: '0644'
+  when: bbb_custom_logo is defined
+
 - name: Set cron.daily specifications
   become: true
   template:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -196,7 +196,7 @@
   become: true
   copy:
     src: "{{ bbb_custom_logo }}"
-    dest: "{{ bbb_nginx_root | regex_replace('\\/$', '') }}/{{ bbb_custom_logo_name | default('logo.png') }}"
+    dest: "{{ bbb_nginx_root | regex_replace('\\/$', '') }}/images/{{ bbb_custom_logo_name | default('logo.png') }}"
     mode: '0644'
   when: bbb_custom_logo is defined
 


### PR DESCRIPTION
The role can already set a default logo URL, but it can't yet copy a file to the server to be used as default logo. With this PR it can.