### PR TITLE
allow to change default bbb_webrtc_sfu_multikurento value without copy&paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,21 @@ bbb_meteor:
         url: "https://{{ bbb_hostname }}/html5log"
 ```
 
+### Modification of `bbb_webrtc_sfu_multikurento`
+
+To add new keys to `bbb_webrtc_sfu_multikurento`, the defaults are actually stored in `bbb_webrtc_sfu_multikurento_default` and then assigned to `bbb_webrtc_sfu_multikurento`.
+
+That way you can add new keys like something like this:
+```yaml
+tempvar:
+  conference-media-specs:
+    OPUS:
+      maxaveragebitrate: "64000"
+
+
+bbb_webrtc_sfu_multikurento: "{{ bbb_webrtc_sfu_multikurento_default | combine(tempvar)  }}"
+```
+
 ### LXD/LXC compatibility
 
 To run BigBlueButton in unprivileged LXD/LXC containers, you have to set `bbb_container_compat` to `true`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -159,7 +159,9 @@ bbb_kurento_interfaces:
 - "{{ ansible_default_ipv4.interface }}"
 - lo
 
-bbb_webrtc_sfu_multikurento:
+# Define a seperate default-variable, as to allow using combine() on this.
+# That way we can add to the default values while redefining 'bbb_webrtc_sfu_multikurento'.
+bbb_webrtc_sfu_multikurento_default:
   balancing-strategy: MEDIA_TYPE
   kurento:
     - ip: "{{ ansible_default_ipv4.address }}"
@@ -202,6 +204,9 @@ bbb_webrtc_sfu_multikurento:
   log:
     level: warn
     filename:
+
+# Assign default values to actual variable.
+bbb_webrtc_sfu_multikurento: "{{ bbb_webrtc_sfu_multikurento_default }}"
 
 # Skip all tasks that are incompatible with (unprivileged) containers
 bbb_container_compat: false


### PR DESCRIPTION
Ansible doesn't allow something like 
```
x=100 #defaults/main.yml

x=x+1 #groupvars/bbb-conf.yml
```
or rather
```
bbb_webrtc_sfu_multikurento: [default value]
bbb_webrtc_sfu_multikurento: "{{ bbb_webrtc_sfu_multikurento | combine({'conference-media-specs':{'OPUS':{'maxaveragebitrate': '64000'}}})  }}"
```
because it references a variable that is being defined at that time. This results in an error `recursive loop detected in template string`.

To make something like this work, I put the variable default value to an underscore-variable first and define the regular variable from that. I.e.
```
_x=100 #defaults/main.yml
x=_x   #defaults/main.yml   

x=_x+1 #groupvars/bbb-conf.yml
```
Now I can use 
```
bbb_webrtc_sfu_multikurento: "{{ _bbb_webrtc_sfu_multikurento | combine({'conference-media-specs':{'OPUS':{'maxaveragebitrate': '64000'}}})  }}"
```
in my group_vars to modify the original defaults without copy&paste...