### PR TITLE
nginx html5 client log format

### DIFF
--- a/files/html5-client-log.conf
+++ b/files/html5-client-log.conf
@@ -1,2 +1,1 @@
-log_format postdata '\$remote_addr [\$time_iso8601] \$request_body';
-
+log_format postdata escape=none '$remote_addr [$time_local] $request_body';


### PR DESCRIPTION
- added `escape=none`
  - no more `sed` needed https://docs.bigbluebutton.org/admin/customize.html#collect-feedback-from-the-users
- changed time format to `$time_local` (same as in default nginx logs)