### PR TITLE
Added option to preserve whitespaces

### DIFF
--- a/templates/bbb-config/bbb-apps/bbb-apps-akka.conf.j2
+++ b/templates/bbb-config/bbb-apps/bbb-apps-akka.conf.j2
@@ -1,3 +1,4 @@
+#jinja2: trim_blocks:False
 // include default config from upstream
 include "/usr/share/bbb-apps-akka/conf/application.conf"
 

--- a/templates/bbb-config/bbb-fsesl/bbb-fsesl-akka.conf.j2
+++ b/templates/bbb-config/bbb-fsesl/bbb-fsesl-akka.conf.j2
@@ -1,3 +1,4 @@
+#jinja2: trim_blocks:False
 // include default config from upstream
 include "/usr/share/bbb-fsesl-akka/conf/application.conf"
 


### PR DESCRIPTION
Added #jinja2: trim_blocks:False to the beginning of the templates for bbb-apps and bbb-fsesl so newlines are preserved, as the previous version threw errors.