### PR TITLE
nodejs 12 to 14

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -263,4 +263,4 @@ bbb_firewall_ufw:
 # https://pypi.org/project/docker-compose/#history
 bbb_docker_compose_version: 1.29.2
 
-bbb_nodejs_version: 12.x
+bbb_nodejs_version: 14.x


### PR DESCRIPTION
- https://docs.bigbluebutton.org/2.4/new.html#whats-new
>Under the hood, BigBlueButton 2.4 installs on Ubuntu 18.04 64-bit, and the following key components have been updated
  Node 14.x (LTS release of Node)