### PR TITLE
Disable unexpected connection rate-limits for ssh

### DIFF
--- a/tasks/firewall/ufw_enable.yml
+++ b/tasks/firewall/ufw_enable.yml
@@ -59,12 +59,6 @@
     rule: allow
     port: "{{ bbb_ssh_port }}"
 
-- name: Connection rate limit for ssh
-  community.general.ufw:
-    rule: limit
-    port: "{{ bbb_ssh_port }}"
-    proto: tcp
-
 - name: allow sip-proxy connection
   community.general.ufw:
     rule: allow


### PR DESCRIPTION
Limiting ssh connections (to 6 per 30 seconds by default) causes issue with ansible runs and seems to be a rather unexpected side-effect for a role that is supposed to 'just' install BBB. Opinionated changes like these should not happen by default, or at least be configurable.