### PR TITLE
Revert upstream freeswitch jitterbuffer experiments

### DIFF
--- a/tasks/freeswitch.yml
+++ b/tasks/freeswitch.yml
@@ -199,6 +199,16 @@
     line: "    <param name=\"wss-binding\" value=\"{{ bbb_freeswitch_ip_address }}:7443\"/>"
   notify: restart freeswitch
 
+# See https://github.com/bigbluebutton/bigbluebutton/issues/7007#issuecomment-621414985
+- name: Revert upstream freeswitch jitterbuffer experiments
+  ansible.builtin.replace:
+    path: "{{item}}"
+    regexp: '(\s+)<action application="jitterbuffer" data="120"/>(\s+)'
+    replace: '\1<action application="jitterbuffer" data="60:120"/>\2'
+  loop:
+  - /opt/freeswitch/etc/freeswitch/dialplan/default/bbb_conference.xml
+  - /opt/freeswitch/etc/freeswitch/dialplan/default/bbb_echo_to_conference.xml
+
 - name: Flush Handler
   meta: flush_handlers
 

--- a/tasks/freeswitch.yml
+++ b/tasks/freeswitch.yml
@@ -202,7 +202,7 @@
 # See https://github.com/bigbluebutton/bigbluebutton/issues/7007#issuecomment-621414985
 - name: Revert upstream freeswitch jitterbuffer experiments
   ansible.builtin.replace:
-    path: "{{item}}"
+    path: "{{ item }}"
     regexp: '(\s+)<action application="jitterbuffer" data="120"/>(\s+)'
     replace: '\1<action application="jitterbuffer" data="60:120"/>\2'
   loop:


### PR DESCRIPTION
The jitterbuffer accepts two parameters: start and maximum buffer length. If no maximum is defined, it defaults to 50 samples (50*20ms = 1s) which is way too large. Packets should be dropped in that case. See https://github.com/bigbluebutton/bigbluebutton/issues/7007#issuecomment-621414985