### PR TITLE
fix issue #309 when systemd-timesyncd is already disabled

### DIFF
--- a/tasks/ntp.yml
+++ b/tasks/ntp.yml
@@ -9,6 +9,9 @@
   package_facts:
     manager: "apt"
 
+- name: Get the list of services
+  service_facts:
+
 - name: Disable/enable chrony service
   service:
     name: chrony
@@ -22,6 +25,7 @@
     name: systemd-timesyncd
     enabled: "{{ (bbb_ntp_cron | bool or 'chrony' in ansible_facts.packages) | ternary('false', 'true') }}"
     state: "{{ (bbb_ntp_cron | bool or 'chrony' in ansible_facts.packages) | ternary('stopped', 'started') }}"
+  when: "'systemd-timesyncd.service' in services and services['systemd-timesyncd.service'].status not in ['not-found','masked']"
 
 - name: Add/remove time syncronisation cronjob
   cron:


### PR DESCRIPTION
Fixes #309 - or at least it works for me.

https://stackoverflow.com/questions/51765306/using-ansible-to-stop-service-that-might-not-exist/65825886#65825886
shows a way to prevent collecting "services" facts if we don't need to, but I didn't go there yet...


For some reason the service had a state of "not-found" on my target system, that's why there's another check.
```
'systemd-timesyncd.service': {'name': 'systemd-timesyncd.service', 'state': 'stopped', 'status': 'not-found', 'source': 'systemd'},
```
