### PR TITLE
Do not use `bufferChatInsertsMs` with BBB 2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,6 @@ bbb_meteor:
       enableNetworkInformation: true
       breakoutRoomLimit: 16
     chat:
-      bufferChatInsertsMs: 100
       typingIndicator:
         enabled: false
     media:


### PR DESCRIPTION
Do not use `bufferChatInsertsMs` with BBB 2.5 until https://github.com/bigbluebutton/bigbluebutton/issues/15185 is fixed.
Setting `bufferChatInsertsMs` leads to losing broadcast messages to breakout rooms.