### PR TITLE
Restore bbb_nginx_listen_https option

### DIFF
--- a/templates/nginx/vhost.conf
+++ b/templates/nginx/vhost.conf
@@ -2,6 +2,8 @@ server {
     listen 80;
     listen [::]:80;
     server_name {{ bbb_hostname }};
+
+{% if bbb_nginx_listen_https %}
     return 301 https://$host$request_uri;
 }
 
@@ -17,6 +19,7 @@ server {
     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
     ssl_prefer_server_ciphers off;
     ssl_dhparam /etc/nginx/ssl/ffdhe4096.pem;
+{% endif %}
 
 {% if bbb_nginx_privacy %}
     error_log /var/log/nginx/bigbluebutton.error.log;


### PR DESCRIPTION
First introduced in #88 / 2c4385b4 but somehow this option got lost along the way.