### PR TITLE
Add option to install even if there are current sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Also check [Before you install](https://docs.bigbluebutton.org/2.5/install.html#
 | | `bbb_turn_enable` | enable the use uf TURN in general | `yes` | |
 | | `bbb_stun_servers` | a list of STUN-Server to use | `{{ bbb_hostname }}` | an array with key `server` - take a look in defaults/main.yml |
 | | `bbb_ice_servers` | a list of RemoteIceCandidate for STUN | `[]` | in array with key `server` |
+| | `bbb_ignore_running_meetings` | install even if meetings are running | `no` | current meetings will be terminated |
 | | `bbb_turn_servers` | a list of TURN-Server to use | `{}` | take a look in defaults/main.yml |
 | | `bbb_mongodb_version` | version of mongodb to be installed | `4.2` | |
 | | `bbb_mongodb_tmpfs_size` | tmpfs size for the mongodb | `512m` | |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ bbb_nginx_privacy: true
 bbb_nginx_listen_https: true
 bbb_nginx_root: /var/www/bigbluebutton-default
 bbb_client_log_enable: false
+bbb_ignore_running_meetings: false
 
 bbb_turn_enable: true
 bbb_stun_servers:

--- a/tasks/check-for-sessions.yml
+++ b/tasks/check-for-sessions.yml
@@ -14,5 +14,6 @@
       meta: end_host
   when:
     - not ansible_check_mode
+    - not bbb_ignore_running_meetings
     - bbb_getmeetings.status == 200
     - "'<messageKey>noMeetings</messageKey>' not in bbb_getmeetings.content"


### PR DESCRIPTION
Sometimes there are sessions that were not terminated even though they are empty (Probably due to a bug); and sometimes for various reasons it doesn't matter if meetings are stopped. For this there should be a switch to continue even if current meetings are found.

This is an improved version of #306.