### PR TITLE
Fix `bbb-fsesl-akka` not connecting to freeswitch

### DIFF
--- a/tasks/freeswitch.yml
+++ b/tasks/freeswitch.yml
@@ -131,7 +131,7 @@
         path: /opt/freeswitch/etc/freeswitch/autoload_configs/event_socket.conf.xml
         xpath: '/configuration/settings/param[@name="listen-ip"]'
         attribute: 'value'
-        value: "{{ '::' if bbb_freeswitch_ipv6 | bool else '127.0.0.1' }}"
+        value: "::1"
       notify: restart freeswitch
 
     - name: stat ipv6 sip_profiles


### PR DESCRIPTION
Listening to `127.0.0.1` breaks bbb-fsesl-akka for unknown reasons ("Failed to connect to ESL"). I suspect that recent versions try to connect to localhost via IPv6. Listening to `::` fixes bbb-fsesl-akka, but exposes that port to the internet if no firewall is installed. The value `::1` does the right thing in all cases: Freeswitch will listen to both IPv4 and IPv4 connections on localhost only.