### PR TITLE
Path to images folder for custom logo has changed

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -169,7 +169,7 @@
   become: true
   copy:
     src: "{{ bbb_custom_logo }}"
-    dest: "{{ bbb_nginx_root | regex_replace('\\/$', '') }}/images/{{ bbb_custom_logo_name | default('logo.png') }}"
+    dest: "{{ bbb_nginx_root | regex_replace('\\/$', '') }}/assets/images/{{ bbb_custom_logo_name | default('logo.png') }}"
     mode: '0644'
   when: bbb_custom_logo is defined
 


### PR DESCRIPTION
Fixes
```
TASK [bbb-node : set custom logo] *********************************************************************************************************
fatal: [bbb-testing.rz.tu-clausthal.de]: FAILED! => {
    "changed": false,
    "checksum": "1ad927548543284b7ea396bd19c79b1080190601"
}

MSG:

Destination directory /var/www/bigbluebutton-default/images does not exist
```
The path now seems to be `/var/www/bigbluebutton-default/assets/images`.