### PR TITLE
make sure FreeSWITCH event_socket listens on 127.0.0.1

### DIFF
--- a/tasks/freeswitch.yml
+++ b/tasks/freeswitch.yml
@@ -125,13 +125,13 @@
 
 - name: configure IPv6-Support in freeswitch
   block:
-    - name: configure listen-ip in event_socket.conf.xml
+    - name: make sure listen-ip in event_socket.conf.xml stays ipv4-localhost
       become: true
       community.general.xml:
         path: /opt/freeswitch/etc/freeswitch/autoload_configs/event_socket.conf.xml
         xpath: '/configuration/settings/param[@name="listen-ip"]'
         attribute: 'value'
-        value: "::1"
+        value: "127.0.0.1"
       notify: restart freeswitch
 
     - name: stat ipv6 sip_profiles


### PR DESCRIPTION
bbb-fsesl-akka and bbb-webrtc-sfu both connect to 127.0.0.1:8021 by default, so we need to make sure that the event_socket listens on 127.0.0.1.
I haven't just removed that task because there probably are some users that will use the role incrementally on an existing host.

This assumes that those users didn't fix the issue manually by reconfiguring bbb-fsesl-akka and bbb-webrtc-sfu. Ideally, of course we'd need to check whether their settings are still default, but that's probably a bit tricky...