### PR TITLE
bbb-webrtc-sfu.service: do not set CPUSchedulingPolicy in a container

### DIFF
--- a/templates/bbb-webrtc-sfu/bbb-webrtc-sfu.override
+++ b/templates/bbb-webrtc-sfu/bbb-webrtc-sfu.override
@@ -1,2 +1,6 @@
 [Unit]
 After=syslog.target network.target freeswitch.service kurento-media-server-8888.service kurento-media-server-8889.service kurento-media-server-8890.service redis-server.service
+{%if bbb_container_compat %}
+[Service]
+CPUSchedulingPolicy=
+{% endif %}


### PR DESCRIPTION
BBB 2.6 does not work correctly in LXC containers, as the unit file of `bbb-webrtc-sfu` sets `CPUSchedulingPolicy`, which is not supported there.

This adjusts the already existing override file to unset the option when `bbb_container_compat` is enabled