### PR TITLE
Fix collecting bbb_secret if bbb isn't installed

### DIFF
--- a/tasks/bbb_secret.yml
+++ b/tasks/bbb_secret.yml
@@ -1,16 +1,27 @@
 ---
-- name: Set bbb_secret as fact
+- name: Set bbb_secret as fact if bbb-conf is present
   when: bbb_secret is not defined
   block:
-    - name: Register bbb secret
+    - name: Check if bbb-conf is present
       become: true
-      command: bbb-conf --secret
+      command: which bbb-conf
       changed_when: false
+      failed_when: which_bbb_conf.rc not in [0, 1]
       check_mode: false
-      register: result
+      register: which_bbb_conf
 
-    - name: Parse bbb secret
-      set_fact:
-        bbb_secret: "{{ result.stdout | regex_search('Secret: ([a-zA-Z0-9]*)', multiline=True) | regex_replace('Secret: ') }}"
-        cacheable: true
-      when: result.rc == 0
+    - name: Set bbb_secret as fact
+      when: which_bbb_conf.rc == 0
+      block:
+        - name: Register bbb secret
+          become: true
+          command: bbb-conf --secret
+          changed_when: false
+          check_mode: false
+          register: result
+
+        - name: Parse bbb secret
+          set_fact:
+            bbb_secret: "{{ result.stdout | regex_search('Secret: ([a-zA-Z0-9]*)', multiline=True) | regex_replace('Secret: ') }}"
+            cacheable: true
+          when: result.rc == 0


### PR DESCRIPTION
### Actual behavior
If bbb isn't already installed, the role will fail at first run.
```shell
TASK [ebbba.bigbluebutton : Include bbb_secret] ****************************************************************************************************************************
included: ./roles/ebbba.bigbluebutton/tasks/bbb_secret.yml for host

TASK [ebbba.bigbluebutton : Register bbb secret] **************************************************************************************************************************
fatal: [host]: FAILED! => {"changed": false, "cmd": "bbb-conf --secret", "msg": "[Errno 2] No such file or directory: b'bbb-conf'", "rc": 2, "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

PLAY RECAP **************************************************************************************************************************
host : ok=37   changed=12   unreachable=0    failed=1    skipped=24   rescued=0    ignored=0
localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

### Expected behavior
Check if bbb is installed and if not, skip bbb_secret-tasks and continue. The `include_tasks` for `check-for-sessions.yml` would also be skipped.
There is already a task for later use of bbb_secret in config.yml.