### PR TITLE
Set $real_scheme variable in nginx config

### DIFF
--- a/templates/nginx/vhost.conf
+++ b/templates/nginx/vhost.conf
@@ -25,6 +25,12 @@ server {
     error_log /var/log/nginx/bigbluebutton.error.log;
 {% endif %}
 
+{% if bbb_nginx_listen_https %}
+    set $real_scheme "https";
+{% else %}
+    set $real_scheme $scheme;
+{% endif %}
+
   location / {
     root   {{ bbb_nginx_root | regex_replace('\\/$', '') }};
     index  index.html index.htm;


### PR DESCRIPTION
_$real_scheme_ was introduced in bigbluebutton/bbb-install, commit [51bc3d11d554a5cc24e0a610b7ab15505066fa52](https://github.com/bigbluebutton/bbb-install/commit/51bc3d11d554a5cc24e0a610b7ab15505066fa52).

The variable is used in  `/usr/share/bigbluebutton/nginx/notes.nginx` from apt package `bbb-etherpad.`. nginx needs the variable to be set in order to start.