### PR TITLE
Fix All-in-one compose starting monitoring task to use var directory

### DIFF
--- a/tasks/monitoring/all_in_one.yml
+++ b/tasks/monitoring/all_in_one.yml
@@ -19,5 +19,5 @@
 - name: Start monitoring
   community.docker.docker_compose:
     pull: true
-    project_src: /root/bbb-monitoring/
+    project_src: "{{ bbb_monitoring_all_in_one_directory }}"
   when: bbb_monitoring_all_in_one_enable | bool


### PR DESCRIPTION
Replace fixed path "/root/bbb-monitoring/" to use bbb_monitoring_all_in_one_directory var

Related to #303