### PR TITLE
Only run certificate related tasks when https is enabled

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,6 +48,7 @@
   tags: mongodb
 
 - import_tasks: certificate.yml
+  when: bbb_nginx_listen_https | bool
   tags:
     - tls
     - certificates


### PR DESCRIPTION
If Nginx will not be listening on port 443, then there is no need to generate certificates. Without this setting, the playbook will fail at the "Ensure bbb_ssl_cert exists" task because no SSL certificate will have been generated.