### PR TITLE
Fix 'dubious ownership' when installing prometheus exporter

### DIFF
--- a/tasks/monitoring/systemd.yml
+++ b/tasks/monitoring/systemd.yml
@@ -15,14 +15,6 @@
   notify:
     - Restart monitoring service
 
-- name: Change ownership directory
-  file:
-    path: "{{ bbb_monitoring_systemd_directory }}"
-    state: directory
-    owner: bbb-exporter
-    group: bbb-exporter
-    mode: "0755"
-
 - name: Ensure pip is installed
   apt:
     name:


### PR DESCRIPTION
When installing the prometheus monitoring exporter, the role fails when running the playbook for the second time, because the bbb-exporter's home directory, the cloned repository, is owned by the bbb-exporter user, who could modify the contents which could lead to privilege escalation. So ansible stops the playbook at that point. Retaining ownership with the root user keeps bbb-exporter from potentially being able to modify anything and the role finishes successfully.

This problem occurs when running with bbb_monitoring_external: true