### PR TITLE
Fix bbb_exporter docker deployment

### DIFF
--- a/templates/monitoring/docker-compose.yaml.j2
+++ b/templates/monitoring/docker-compose.yaml.j2
@@ -5,6 +5,7 @@ services:
     image: greenstatic/bigbluebutton-exporter:{{ bbb_monitoring_exporter_version }}
     network_mode: host
     volumes:
+      - "/etc/bigbluebutton/bigbluebutton-release:/etc/bigbluebutton/bigbluebutton-release:ro"
       # Can be removed if `RECORDINGS_METRICS_READ_FROM_DISK` is set to false (or omitted).
       # See https://bigbluebutton-exporter.greenstatic.dev/exporter-user-guide/#optimizations for details.
       - "/var/bigbluebutton:/var/bigbluebutton:ro"


### PR DESCRIPTION
Mount `/etc/bigbluebutton/bigbluebutton-release` in bbb_exporter docker container.
This is needed for bbb_exporter to export the deployed BBB version.

Otherwise `bbb_exporter:latest` fails to start with:
```
bbb-exporter   | Traceback (most recent call last):
bbb-exporter   |   File "server.py", line 46, in <module>
bbb-exporter   |     REGISTRY.register(collector)
bbb-exporter   |   File "/usr/local/lib/python3.8/site-packages/prometheus_client/registry.py", line 24, in register
bbb-exporter   |     names = self._get_names(collector)
bbb-exporter   |   File "/usr/local/lib/python3.8/site-packages/prometheus_client/registry.py", line 64, in _get_names
bbb-exporter   |     for metric in desc_func():
bbb-exporter   |   File "/app/collector.py", line 111, in collect
bbb-exporter   |     with open("/etc/bigbluebutton/bigbluebutton-release", "r") as f:
bbb-exporter   | FileNotFoundError: [Errno 2] No such file or directory: '/etc/bigbluebutton/bigbluebutton-release'
bbb-exporter exited with code 1
```